### PR TITLE
add  SE (ncol) →  lat/lon regridding directly inside ADF via xESMF

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -12,6 +12,30 @@ A scannable reference for the ADF YAML config
 
 ---
 
+## Contents
+
+- [What a complete config file must contain](#what-a-complete-config-file-must-contain)
+  - [Tier 1 — Truly required (ADF fails or produces nothing without them)](#tier-1--truly-required-adf-fails-or-produces-nothing-without-them)
+  - [Tier 2 — The diagnostic pipeline (required in practice)](#tier-2--the-diagnostic-pipeline-required-in-practice)
+  - [Tier 3 — Optional features (off unless you turn them on)](#tier-3--optional-features-off-unless-you-turn-them-on)
+- [Variable substitution (`${...}`)](#variable-substitution-)
+- [Top-level keys](#top-level-keys)
+- [`Section: diag_basic_info`](#section-diag_basic_info)
+  - [SE (`ncol`) → lat/lon regridding — how it works](#se-ncol--latlon-regridding--how-it-works)
+- [`Section: diag_cam_climo`](#section-diag_cam_climo)
+- [`Section: diag_cam_baseline_climo`](#section-diag_cam_baseline_climo)
+- [`Section: diag_cvdp_info`](#section-diag_cvdp_info)
+- [`Section: diag_mdtf_info`](#section-diag_mdtf_info)
+- [Script lists — which diagnostics to run](#script-lists--which-diagnostics-to-run)
+- [`Section: time_averaging_scripts`](#section-time_averaging_scripts)
+- [`Section: regridding_scripts`](#section-regridding_scripts)
+- [`Section: analysis_scripts`](#section-analysis_scripts)
+- [`Section: plotting_scripts`](#section-plotting_scripts)
+- [`Section: diag_var_list`](#section-diag_var_list)
+- [`Section: region_multicase`](#section-region_multicase)
+
+---
+
 ## What a complete config file must contain
 
 Sections fall into **three tiers**, not simply "required vs optional":

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -15,9 +15,8 @@ A scannable reference for the ADF YAML config
 ## Contents
 
 - [What a complete config file must contain](#what-a-complete-config-file-must-contain)
-  - [Tier 1 — Truly required (ADF fails or produces nothing without them)](#tier-1--truly-required-adf-fails-or-produces-nothing-without-them)
-  - [Tier 2 — The diagnostic pipeline (required in practice)](#tier-2--the-diagnostic-pipeline-required-in-practice)
-  - [Tier 3 — Optional features (off unless you turn them on)](#tier-3--optional-features-off-unless-you-turn-them-on)
+  - [Tier 1 — Required (ADF fails or produces nothing without them)](#tier-1--truly-required-adf-fails-or-produces-nothing-without-them)
+  - [Tier 2 — Optional features (off unless you turn them on)](#tier-2--optional-features-off-unless-you-turn-them-on)
 - [Variable substitution (`${...}`)](#variable-substitution-)
 - [Top-level keys](#top-level-keys)
 - [`Section: diag_basic_info`](#section-diag_basic_info)
@@ -26,7 +25,6 @@ A scannable reference for the ADF YAML config
 - [`Section: diag_cam_baseline_climo`](#section-diag_cam_baseline_climo)
 - [`Section: diag_cvdp_info`](#section-diag_cvdp_info)
 - [`Section: diag_mdtf_info`](#section-diag_mdtf_info)
-- [Script lists — which diagnostics to run](#script-lists--which-diagnostics-to-run)
 - [`Section: time_averaging_scripts`](#section-time_averaging_scripts)
 - [`Section: regridding_scripts`](#section-regridding_scripts)
 - [`Section: analysis_scripts`](#section-analysis_scripts)
@@ -38,42 +36,28 @@ A scannable reference for the ADF YAML config
 
 ## What a complete config file must contain
 
-Sections fall into **three tiers**, not simply "required vs optional":
+Sections fall into **two tiers**:, not simply "required vs optional":
 
 ### Tier 1 — Truly required (ADF fails or produces nothing without them)
 
 | Section | Notes |
 |---------|-------|
-| `diag_basic_info` | Shared settings. Read with `required=True`. |
+| `diag_basic_info` | Basic info that applies to all runs. |
 | `diag_cam_climo` | The case being diagnosed. |
-| `diag_var_list` | Which variables to process/plot. With none, there is nothing to do. |
+| `diag_var_list` | Which variables to process/plot. |
 | `diag_cam_baseline_climo` | **Required when `compare_obs: false`** (model-vs-model) — the baseline case to compare against. Not needed when `compare_obs: true`. |
+| `time_averaging_scripts` | Climatology creation |
+| `regridding_scripts` | Regrid model lat/lon climo → observation/baseline grid (+ vertical interp, hybrid→pressure) so model and reference are directly comparable |
+| `analysis_scripts` | Tables (e.g. `amwg_table`) |
+| `plotting_scripts` | Plots |
 
-### Tier 2 — The diagnostic pipeline (required in practice)
-
-These four lists drive the actual work. The **code** tolerates a missing/empty
-list — it prints a notice (e.g. *"No regridding options provided, continue."*)
-and continues without erroring — but you should treat all four as **required**:
-without them, running ADF has no value. In particular, **without
-`regridding_scripts` there is no model↔reference comparison at all**, which is
-the whole point of the ADF.
-
-| Section | Drives | If omitted |
-|---------|--------|-----------|
-| `time_averaging_scripts` | Climatology creation | No climo files made. |
-| `regridding_scripts` | **Regrid model lat/lon climo → observation/baseline grid** (+ vertical interp, hybrid→pressure) so model and reference are directly comparable | **No comparison possible** — the core purpose of ADF is lost. |
-| `analysis_scripts` | Tables (e.g. `amwg_table`) | No tables. |
-| `plotting_scripts` | Plots | No plots. |
-
-> **Note — two different "regriddings":** `regridding_scripts`
+> **Note — there are two different "regriddings" that occur :** `regridding_scripts`
 > (`regrid_and_vert_interp`) regrids the model's **lat/lon** climatology onto the
 > **observation/baseline** grid for comparison. This is *separate* from the
-> SE regridding we added, which converts native **`ncol` → lat/lon** during
+> SE regridding, which converts native **`ncol` → lat/lon** during
 > time-series creation (see the "SE (`ncol`) → lat/lon regridding" section).
-> First `ncol`→lat/lon (makes data usable), then lat/lon→reference (makes it
-> comparable).
 
-### Tier 3 — Optional features (off unless you turn them on)
+### Tier 2 — Optional features (off unless you turn them on)
 
 | Section | Notes |
 |---------|-------|
@@ -223,16 +207,8 @@ NOAA MDTF (Model Diagnostics Task Force) diagnostics (optional, CASPER only).
 
 ---
 
-## Script lists — which diagnostics to run
-
-Each of the four sections below contain script names (without `.py`) in the corresponding
-`scripts/<kind>/` directory. Add a script to a list to enable it; remove it to
-disable it. See Tiers 1–2 above for how required each list is.
-
----
-
 ## `Section: time_averaging_scripts`
-Climatology averaging (`scripts/averaging/`).
+Climatology averaging. Add any of the scripts in `scripts/averaging/` directory but without the .`py` extension.
 
 | Script | What it does |
 |--------|--------------|
@@ -242,7 +218,7 @@ Climatology averaging (`scripts/averaging/`).
 ---
 
 ## `Section: regridding_scripts`
-Regrid model climo to the reference grid (`scripts/regridding/`).
+Regrid model climo to the reference grid. Add any of the scripts in `scripts/regridding/` directory but without the .`py` extension.
 
 | Script | What it does |
 |--------|--------------|
@@ -251,7 +227,7 @@ Regrid model climo to the reference grid (`scripts/regridding/`).
 ---
 
 ## `Section: analysis_scripts`
-Tables (`scripts/analysis/`).
+Analysis functionality. Add any of the scripts in `scripts/analysis/` directory but without the .`py` extension.
 
 | Script | What it does |
 |--------|--------------|
@@ -262,9 +238,8 @@ Tables (`scripts/analysis/`).
 ---
 
 ## `Section: plotting_scripts`
-Plots (`scripts/plotting/`).
-
-Scripts marked **(NCAR obs)** hard-code observation paths on NCAR `/glade` and
+Plotting scripts. Add any of the scripts in `scripts/plotting/` directory but without the .`py` extension.
+NIRD NOTE: Scripts marked **(NCAR obs)** have hard-code observation paths on NCAR `/glade` and
 generally won't work on NIRD without those datasets. More broadly, several
 scripts compare against bundled observations (e.g. `qbo`, `tape_recorder`,
 `aod_latlon` use ERA5 / MLS / MODIS): **the observation data may not be present
@@ -292,10 +267,8 @@ on NIRD**, so confirm the obs are reachable before enabling these.
 ---
 
 ## `Section: diag_var_list`
-Variables to process.
-
-A flat list of CAM variable names to diagnose. Notes:
-
+A flat list of CAM variable names to Plot.
+Notes:
 - **Aerosol column burdens** (`cb_*`), **surface fluxes** (`SF*`), and **optical
   depths** (`AOD*`, `D550_*`) are *derived* — ADF auto-adds `PMID` and `T` when
   any aerosol variable is requested.
@@ -309,7 +282,6 @@ A flat list of CAM variable names to diagnose. Notes:
 
 ## `Section: region_multicase`
 Regional multi-case maps (optional).
-
 Custom options for the **`regional_map_multicase`** plotting script, which draws
 regional contour maps of variables for **all cases (up to 10) side by side**.
 Only used if `regional_map_multicase` is listed in `plotting_scripts` **and**
@@ -338,4 +310,3 @@ region_multicase:
         - PRECT
         - TS
 ```
-

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -1,14 +1,61 @@
-# NorESM ADF config reference
+# ADF config reference
 
-A scannable reference for the ADF NorESM YAML config
-(`config_noresm_default.yaml` / `config_noresm_default_summary.yaml`).
+A scannable reference for the ADF YAML config
+(see `config_noresm_default.yaml` as an example).
 
-- **Run/edit** the bare-bones file (`config_noresm_default_summary.yaml`) — no comments, just values.
+- **Run/edit** one of the the bare-bones file (e.g. `config_noresm_default.yaml`) — no comments, just values.
 - **Look things up** here.
 
 > Every key below lives under a top-level *section* (e.g. `diag_basic_info:`).
 > Indentation and section placement matter — a key placed in the wrong section
 > is silently ignored.
+
+---
+
+## What a complete config file must contain
+
+Sections fall into **three tiers**, not simply "required vs optional":
+
+### Tier 1 — Truly required (ADF fails or produces nothing without them)
+
+| Section | Notes |
+|---------|-------|
+| `diag_basic_info` | Shared settings. Read with `required=True`. |
+| `diag_cam_climo` | The case being diagnosed. |
+| `diag_var_list` | Which variables to process/plot. With none, there is nothing to do. |
+| `diag_cam_baseline_climo` | **Required when `compare_obs: false`** (model-vs-model) — the baseline case to compare against. Not needed when `compare_obs: true`. |
+
+### Tier 2 — The diagnostic pipeline (required in practice)
+
+These four lists drive the actual work. The **code** tolerates a missing/empty
+list — it prints a notice (e.g. *"No regridding options provided, continue."*)
+and continues without erroring — but you should treat all four as **required**:
+without them, running ADF has no value. In particular, **without
+`regridding_scripts` there is no model↔reference comparison at all**, which is
+the whole point of the ADF.
+
+| Section | Drives | If omitted |
+|---------|--------|-----------|
+| `time_averaging_scripts` | Climatology creation | No climo files made. |
+| `regridding_scripts` | **Regrid model lat/lon climo → observation/baseline grid** (+ vertical interp, hybrid→pressure) so model and reference are directly comparable | **No comparison possible** — the core purpose of ADF is lost. |
+| `analysis_scripts` | Tables (e.g. `amwg_table`) | No tables. |
+| `plotting_scripts` | Plots | No plots. |
+
+> **Note — two different "regriddings":** `regridding_scripts`
+> (`regrid_and_vert_interp`) regrids the model's **lat/lon** climatology onto the
+> **observation/baseline** grid for comparison. This is *separate* from the
+> SE regridding we added, which converts native **`ncol` → lat/lon** during
+> time-series creation (see the "SE (`ncol`) → lat/lon regridding" section).
+> First `ncol`→lat/lon (makes data usable), then lat/lon→reference (makes it
+> comparable).
+
+### Tier 3 — Optional features (off unless you turn them on)
+
+| Section | Notes |
+|---------|-------|
+| `diag_cvdp_info` | **Omit the whole section to disable**, or keep it with `cvdp_run: false`. Equivalent — a missing section is read as `None` and skipped. |
+| `diag_mdtf_info` | **Omit the whole section to disable**, or keep it with `mdtf_run: false`. Same behavior as CVDP. |
+| `region_multicase` | **Omit to disable.** Only used when `regional_map_multicase` is in `plotting_scripts`. Missing section → read as `None` → skipped. |
 
 ---
 
@@ -27,14 +74,16 @@ Notes: keywords must be **lowercase**; avoid periods (`.`) in variable names (br
 
 | Key | Required | Example | Description |
 |-----|----------|---------|-------------|
-| `user` | **yes** | `mvertens` | Username; used in many default paths. `USER-NAME-NOT-SET` is the "not customized" sentinel. |
-| `case` | optional | `N1850.ne30pg3...` | Convenience handle for the test case, referenced as `${case}`. |
-| `nick` | optional | `noresm3_ne30_beta20` | Nickname for the test case (`${nick}`). |
-| `case2` / `nick2` | optional | — | Same, for a second (baseline) case. |
+| `user` | **yes** | `<user_name>` | Username; used in many default paths. `USER-NAME-NOT-SET` is the "not customized" sentinel. |
+| `case` | **yes** | `<case name>` | The primary case name. The config references it as `${case}` (e.g. `cam_case_name: ${case}`), so it must be set or the substitution fails. |
+| `nick` | **yes** | `<case nickname>` | Nickname for the primary case, referenced as `${nick}` (e.g. `case_nickname: ${nick}`). Must be set wherever `${nick}` is used. |
+| `case_base` | **yes if `compare_obs: false`** | `<case_base>` | The baseline case name, referenced as `${case2}`. Required for the model-vs-model comparison. |
+| `nick_base` | **yes if `compare_obs: false`** | `<case_base nickname>` | Baseline nickname, referenced as `${nick2}`. |
 
 ---
 
-## `diag_basic_info` — settings shared by all runs
+## `Section: diag_basic_info`
+Settings shared by all runs.
 
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
@@ -56,7 +105,7 @@ Notes: keywords must be **lowercase**; avoid periods (`.`) in variable names (br
 
 ---
 
-## SE (`ncol`) → lat/lon regridding — how it works
+### SE (`ncol`) → lat/lon regridding — how it works
 
 The three `cam_se_*` keys control **in-core** regridding of native CAM
 spectral-element output to a regular lat/lon grid. It happens automatically
@@ -81,7 +130,8 @@ every downstream step (climatologies, tables, plots) reads lat/lon.
 
 ---
 
-## `diag_cam_climo` — the case being diagnosed
+## `Section: diag_cam_climo`
+The case being diagnosed.
 
 | Key | Required | Example / Default | Description |
 |-----|----------|-------------------|-------------|
@@ -104,7 +154,8 @@ every downstream step (climatologies, tables, plots) reads lat/lon.
 
 ---
 
-## `diag_cam_baseline_climo` — the baseline case (only if `compare_obs: false`)
+## `Section: diag_cam_baseline_climo`
+The baseline case (only if `compare_obs: false`).
 
 Same keys as `diag_cam_climo` (reference them as `${diag_cam_baseline_climo.xxx}`).
 Distinct values worth noting:
@@ -120,7 +171,8 @@ Distinct values worth noting:
 
 ---
 
-## `diag_cvdp_info` — Climate Variability Diagnostics Package (optional)
+## `Section: diag_cvdp_info`
+Climate Variability Diagnostics Package (optional).
 
 | Key | Default | Description |
 |-----|---------|-------------|
@@ -131,7 +183,8 @@ Distinct values worth noting:
 
 ---
 
-## `diag_mdtf_info` — NOAA MDTF diagnostics (optional, CASPER only)
+## `Section: diag_mdtf_info`
+NOAA MDTF (Model Diagnostics Task Force) diagnostics (optional, CASPER only).
 
 | Key | Default | Description |
 |-----|---------|-------------|
@@ -146,21 +199,76 @@ Distinct values worth noting:
 
 ---
 
-## Script lists — which diagnostics run
+## Script lists — which diagnostics to run
 
-Each list names scripts (without `.py`) in the corresponding `scripts/<kind>/` dir.
-Pass kwargs like: `- {create_climo_files: {kwargs: {clobber: true}}}`.
-
-| Section | Dir | Typical entries |
-|---------|-----|-----------------|
-| `time_averaging_scripts` | `scripts/averaging` | `create_climo_files` (`create_TEM_files` optional) |
-| `regridding_scripts` | `scripts/regridding` | `regrid_and_vert_interp` |
-| `analysis_scripts` | `scripts/analysis` | `amwg_table` |
-| `plotting_scripts` | `scripts/plotting` | `global_mean_timeseries`, `global_latlon_map`, `global_latlon_vect_map`, `zonal_mean`, `meridional_mean`, `polar_map`, `cam_taylor_diagram`, `ozone_diagnostics`, `qbo` (`tape_recorder`, `tem` optional) |
+Each of the four sections below contain script names (without `.py`) in the corresponding
+`scripts/<kind>/` directory. Add a script to a list to enable it; remove it to
+disable it. See Tiers 1–2 above for how required each list is.
 
 ---
 
-## `diag_var_list` — variables to process
+## `Section: time_averaging_scripts`
+Climatology averaging (`scripts/averaging/`).
+
+| Script | What it does |
+|--------|--------------|
+| `create_climo_files` | Compute climatologies from the time series. Overwriting is controlled by `cam_overwrite_climo` (not a `clobber` kwarg). |
+| `create_TEM_files` | *(optional)* Generate TEM diagnostic input files (for the `tem` plot). |
+
+---
+
+## `Section: regridding_scripts`
+Regrid model climo to the reference grid (`scripts/regridding/`).
+
+| Script | What it does |
+|--------|--------------|
+| `regrid_and_vert_interp` | Regrid the model's **lat/lon** climatology onto the **observation/baseline** grid, plus vertical interpolation (hybrid → pressure), so model and reference are directly comparable. *(Distinct from the SE `ncol`→lat/lon regrid — see that section.)* |
+
+---
+
+## `Section: analysis_scripts`
+Tables (`scripts/analysis/`).
+
+| Script | What it does |
+|--------|--------------|
+| `amwg_table` | Builds the AMWG summary-statistics **table**, one row per variable: global average → annual average → mean, sample size, std-dev, standard error, 5/95% confidence interval, and linear trend. |
+| `aerosol_gas_tables` | **Aerosol and gaseous budget tables** (burdens/sources/sinks). Default gases `CH4, CH3CCL3, CO, O3, ISOP, MTERP, CH3OH, CH3COCH3`; aerosols `AOD, SOA, SALT, DUST, POM, BC, SO4` (set in `lib/adf_variable_defaults.yaml`). |
+| `ENSO_acrossRuns` | Computes **ENSO statistics** across cases; feeds `enso_comparison_plots`. |
+
+---
+
+## `Section: plotting_scripts`
+Plots (`scripts/plotting/`).
+
+Scripts marked **(NCAR obs)** hard-code observation paths on NCAR `/glade` and
+generally won't work on NIRD without those datasets. More broadly, several
+scripts compare against bundled observations (e.g. `qbo`, `tape_recorder`,
+`aod_latlon` use ERA5 / MLS / MODIS): **the observation data may not be present
+on NIRD**, so confirm the obs are reachable before enabling these.
+
+| Script | What it plots |
+|--------|---------------|
+| `global_latlon_map` | Global 2-D **lat/lon maps** of model fields with continental overlays (model vs obs/baseline). |
+| `global_latlon_vect_map` | Global 2-D lat/lon maps of **vector fields** (e.g. winds) with continental overlays. |
+| `global_mean_timeseries` | **Global-mean, annual-mean time series** per case on one combined plot (can include CESM2 LENS). |
+| `zonal_mean` | **Zonal averages** (annual and seasonal) vs obs/baseline. |
+| `meridional_mean` | **Meridional averages** (default tropical 5°S–5°N band) vs obs/baseline. |
+| `polar_map` | **Polar maps** (NH or SH) of model fields with continental overlays. |
+| `cam_taylor_diagram` | **Taylor diagrams** summarizing model skill. Model-vs-model only — skipped when `compare_obs: true`. |
+| `qbo` | **QBO diagnostics**: 5°S–5°N zonal-mean U time series + Dunkerton–Delisi QBO amplitude, vs ERA5. |
+| `ozone_diagnostics` | **Ozone** comparisons vs ozonesonde / CAM-chem observations. **(NCAR obs)** |
+| `aod_latlon` | **AOD** (aerosol optical depth) lat/lon comparison vs TERRA MODIS / MERRA2. |
+| `tape_recorder` | Tropical (10°S–10°N) stratospheric water-vapor **"tape recorder"** (Q vs MLS and ERA5). |
+| `tem` | **TEM** (Transformed Eulerian Mean) 2-D latitude-vs-pressure maps. Needs TEM files (`cam_tem_loc`); skipped if missing. |
+| `adf_histogram` | **Histograms** (distribution comparison of variables across cases). |
+| `MOPITT` | CO comparison vs **MOPITT** satellite CO climatology. **(NCAR obs)** |
+| `enso_comparison_plots` | **ENSO** comparison plots across simulations (uses `ENSO_acrossRuns` output). |
+| `regional_map_multicase` | Regional contour maps of variables for up to 10 cases side by side. Needs the **`region_multicase`** config section (documented above). |
+
+---
+
+## `Section: diag_var_list`
+Variables to process.
 
 A flat list of CAM variable names to diagnose. Notes:
 
@@ -175,34 +283,35 @@ A flat list of CAM variable names to diagnose. Notes:
 
 ---
 
-## Minimal working example (bare-bones)
+## `Section: region_multicase`
+Regional multi-case maps (optional).
 
+Custom options for the **`regional_map_multicase`** plotting script, which draws
+regional contour maps of variables for **all cases (up to 10) side by side**.
+Only used if `regional_map_multicase` is listed in `plotting_scripts` **and**
+this section is present; otherwise it is read as `None` and skipped.
+
+| Key | Description |
+|-----|-------------|
+| `region_spec` | Region box as `[slat, nlat, wlon, elon]` (south lat, north lat, west lon, east lon). |
+| `region_time_option` | `calendar` → use the explicit `region_start_year`/`region_end_year`. `zeroanchor` → use `region_nyear` years starting `region_year_offset` from the beginning of the time series. |
+| `region_start_year` / `region_end_year` | Year range (used when `region_time_option: calendar`). |
+| `region_nyear` / `region_year_offset` | Number of years, and offset from the series start (used when `region_time_option: zeroanchor`). |
+| `region_month` | Month to plot. `NULL` → fall back to `region_season`. |
+| `region_season` | Season to plot. `NULL` → annual mean. |
+| `region_variables` | List of variables to plot — a subset of `diag_var_list`. |
+
+Example:
 ```yaml
-user: 'mvertens'
-case: 'n1850.ne16pg3_tn14.noresm3_0_beta21.476.2026-07-03'
-nick: 'beta21_ne16'
-
-diag_basic_info:
-    hist_str: cam.h0a
-    compare_obs: false
-    create_html: true
-    cam_regrid_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/tseries/regrid
-    cam_overwrite_regrid: false
-    cam_se_grid: ne16                     # ne16 | ne30 | (omit to skip regridding)
-    cam_se_weight_file_ne16: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc
-    cam_se_weight_file_ne30: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc
-    cam_diag_plot_loc: /nird/datalake/NS2345K/www/diagnostics/ADF/${user}
-    num_procs: 8
-    redo_plot: true
-
-diag_cam_climo:
-    cam_case_name: ${case}
-    case_nickname: ${nick}
-    cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_climo.cam_case_name}/atm/hist
-    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo
-    cam_ts_loc:    /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries_regridded
-    start_year: 960
-    end_year: 969
-    cam_ts_done: false
-    cam_overwrite_ts: false
+region_multicase:
+    region_spec: [-30, 30, 0, 360]      # tropics
+    region_time_option: zeroanchor
+    region_nyear: 10
+    region_year_offset: 0
+    region_month:                       # NULL -> use season
+    region_season:                      # NULL -> annual mean
+    region_variables:
+        - PRECT
+        - TS
 ```
+

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -1,0 +1,208 @@
+# NorESM ADF config reference
+
+A scannable reference for the ADF NorESM YAML config
+(`config_noresm_default.yaml` / `config_noresm_default_summary.yaml`).
+
+- **Run/edit** the bare-bones file (`config_noresm_default_summary.yaml`) — no comments, just values.
+- **Look things up** here.
+
+> Every key below lives under a top-level *section* (e.g. `diag_basic_info:`).
+> Indentation and section placement matter — a key placed in the wrong section
+> is silently ignored.
+
+---
+
+## Variable substitution (`${...}`)
+
+| Form | Meaning | Example |
+|------|---------|---------|
+| `${xxx}` | Substitute the value of `xxx` (must exist in exactly one place) | `cam_climo_loc: /some/where/${user}` |
+| `${section.xxx}` | Substitute `xxx` from a specific section (needed when the key repeats) | `${diag_cam_climo.cam_case_name}` |
+
+Notes: keywords must be **lowercase**; avoid periods (`.`) in variable names (breaks the parser).
+
+---
+
+## Top-level keys
+
+| Key | Required | Example | Description |
+|-----|----------|---------|-------------|
+| `user` | **yes** | `mvertens` | Username; used in many default paths. `USER-NAME-NOT-SET` is the "not customized" sentinel. |
+| `case` | optional | `N1850.ne30pg3...` | Convenience handle for the test case, referenced as `${case}`. |
+| `nick` | optional | `noresm3_ne30_beta20` | Nickname for the test case (`${nick}`). |
+| `case2` / `nick2` | optional | — | Same, for a second (baseline) case. |
+
+---
+
+## `diag_basic_info` — settings shared by all runs
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `hist_str` | optional | `cam.h0a` | History file string to match (only affects time series). No trailing `.`. |
+| `compare_obs` | optional | `false` | `true` = model-vs-observations; `false`/missing = model-vs-model. |
+| `create_html` | optional | `false` | Generate the HTML website (under `cam_diag_plot_loc/<diag_run>/website`). |
+| `obs_data_loc` | if `compare_obs` | — | Location of observational datasets. |
+| `cam_regrid_loc` | **yes** | — | Where regridded/interpolated **climatology** files are stored. |
+| `cam_overwrite_regrid` | optional | `false` | `false`/missing = skip regridding for files that already exist in `cam_regrid_loc`. |
+| **`cam_se_grid`** | optional | *(unset)* | **SE→lat/lon regrid ON/OFF switch.** See the SE regridding section below. |
+| **`cam_se_weight_file_ne16`** | if `cam_se_grid: ne16` | — | ESMF weight (map) file, ne16pg3 → 1.9×2.5. |
+| **`cam_se_weight_file_ne30`** | if `cam_se_grid: ne30` | — | ESMF weight (map) file, ne30pg3 → 0.5×0.5. |
+| `cam_diag_plot_loc` | **yes** | — | Where diagnostic plots are written. |
+| `defaults_file` | optional | `lib/adf_variable_defaults.yaml` | Custom variable-plotting defaults YAML. |
+| `plot_press_levels` | optional | *(none)* | Pressure levels (hPa) for 3-D vars on lat/lon maps, e.g. `[200,500,850]`. If missing, no 3-D vars plotted on horizontal maps. |
+| `central_longitude` | optional | `180` | Center longitude for lat/lon maps. |
+| `num_procs` | optional | `1` | Processors for parallel steps. `"*"` = all on the node. Does **not** affect SE regrid (that runs serially). |
+| `redo_plot` | optional | `false` | `true` = remake plots even if they exist. |
+
+---
+
+## SE (`ncol`) → lat/lon regridding — how it works
+
+The three `cam_se_*` keys control **in-core** regridding of native CAM
+spectral-element output to a regular lat/lon grid. It happens automatically
+during time-series creation: each time-series file is written on the native
+`ncol` grid and then **overwritten in place** with its lat/lon equivalent, so
+every downstream step (climatologies, tables, plots) reads lat/lon.
+
+**On/off switch — `cam_se_grid`:**
+
+| Value | Effect |
+|-------|--------|
+| `ne16` or `ne30` | Regridding **ON**, using the matching `cam_se_weight_file_*`. |
+| unset / blank | Regridding **OFF** — ADF behaves exactly like stock. Use for already-lat/lon input. |
+
+**Key facts (things that cost time to learn the hard way):**
+
+- **Placement matters:** `cam_se_grid` **must** be in `diag_basic_info` (it's read via `get_basic_info`). Elsewhere = silently ignored, no regridding.
+- **ADF does not inspect the data** to decide whether to regrid — the decision is purely this setting. Safety net: any file with no `ncol` dimension (already lat/lon) is skipped untouched, so leaving the switch on for lat/lon input is harmless.
+- **The target resolution is baked into the weight file** (ne16 → 1.9×2.5, ne30 → 0.5×0.5), *not* chosen here. To change the output grid, use a different weight file.
+- **The weight file's source grid must match the data** (ne16 file expects ne16pg3, ne30 expects ne30pg3), else xESMF errors on a shape mismatch — which is your safeguard against picking the wrong file.
+- **Runs serially, not under `mp.Pool`** — xESMF/ESMF is not fork-safe (a forked worker deadlocks). So `num_procs` does not speed it up, but the regrid is cheap (applying precomputed weights).
+
+---
+
+## `diag_cam_climo` — the case being diagnosed
+
+| Key | Required | Example / Default | Description |
+|-----|----------|-------------------|-------------|
+| `hist_str` | optional | `cam.h0a` | History file(s) to match; list allowed, e.g. `[cam.h2,cam.h0]`. |
+| `calc_cam_climo` | optional | `true` | `false` = don't create climatology files. |
+| `cam_overwrite_climo` | optional | `false` | `false`/missing = skip existing climo files. |
+| `cam_case_name` | **yes** | `n1850.ne30_tn14...` | CAM case (run) name. |
+| `case_nickname` | optional | *(= `cam_case_name`)* | Display nickname. Quote it if it starts with `0`. |
+| `cam_hist_loc` | **yes** | `.../cases/${...}/atm/hist` | Location of CAM history (h0a) files. Point at **native `ncol`** history for in-core regrid, or at pre-regridded lat/lon files to skip it. |
+| `cam_climo_loc` | **yes** | `/scratch/${user}/.../climo` | Where climatologies are created/stored. |
+| `start_year` | optional | *(earliest)* | First model year for time series. Blank = earliest available. |
+| `end_year` | optional | *(latest)* | Last model year for time series. Blank = latest available. |
+| `cam_ts_done` | optional | `false` | `true` = model files are already time series (skip creation). |
+| `cam_ts_save` | optional | `false` | `true` = keep interim time-series files (uses disk, saves time later). |
+| `cam_overwrite_ts` | optional | `false` | `false` = skip time-series creation if files are found. Set `true` to force rebuild. |
+| `cam_ts_loc` | **yes** | `/scratch/${user}/.../tseries` | Where time-series files are (or will be) stored. |
+| `tem_hist_str` | optional | `cam.h4` | TEM history file string. |
+| `cam_tem_loc` | optional | `.../tem/` | Where TEM files are stored. **If unset/commented, TEM is skipped.** |
+| `overwrite_tem` | optional | `false` | `false` = skip TEM creation if files found. |
+
+---
+
+## `diag_cam_baseline_climo` — the baseline case (only if `compare_obs: false`)
+
+Same keys as `diag_cam_climo` (reference them as `${diag_cam_baseline_climo.xxx}`).
+Distinct values worth noting:
+
+| Key | Example | Description |
+|-----|---------|-------------|
+| `cam_case_name` | `n1850.ne30_tn14...20241204` | Baseline case name. |
+| `cam_hist_loc` | `.../cases/${diag_cam_baseline_climo.cam_case_name}/atm/hist` | Baseline history location. |
+| `cam_ts_loc` | `/scratch/${user}/diagnostics/ADF/${...}/atm/tseries` | Baseline time-series location. |
+| `start_year` / `end_year` | `52` / `71` | Baseline year range. |
+
+*(All other keys mirror `diag_cam_climo`.)*
+
+---
+
+## `diag_cvdp_info` — Climate Variability Diagnostics Package (optional)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `cvdp_run` | `false` | Run CVDP (in background; finishes after ADF). Needs `PSL, TREFHT, TS, PRECT` (or `PRECC`+`PRECL`) in `diag_var_list`. |
+| `cvdp_codebase_loc` | — | Path to the CVDP codebase. |
+| `cvdp_loc` | — | Where CVDP is copied to and plots stored. |
+| `cvdp_tar` | `false` | Tar up CVDP results. |
+
+---
+
+## `diag_mdtf_info` — NOAA MDTF diagnostics (optional, CASPER only)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mdtf_run` | `false` | Run MDTF (background). |
+| `mdtf_input_settings_filename` | `mdtf_input.json` | JSON ADF writes for MDTF input. |
+| `mdtf_codebase_path` / `mdtf_codebase_loc` | — | MDTF codebase locations. |
+| `conda_root` / `conda_env_root` | — | Conda locations for MDTF envs. |
+| `OBS_DATA_ROOT` | — | MDTF observation data root. |
+| `MODEL_DATA_ROOT` | `${diag_cam_climo.cam_ts_loc}/mdtf/...` | Writable dir where ADF stages ts files for MDTF. |
+| `pod_list` | `["MJO_suite"]` | Which PODs (diagnostics) to run — each needs specific variables. |
+| `make_variab_tar`, `save_ps`, `save_nc`, `overwrite`, `verbose`, `test_mode`, `dry_run` | — | Output/debug toggles. |
+
+---
+
+## Script lists — which diagnostics run
+
+Each list names scripts (without `.py`) in the corresponding `scripts/<kind>/` dir.
+Pass kwargs like: `- {create_climo_files: {kwargs: {clobber: true}}}`.
+
+| Section | Dir | Typical entries |
+|---------|-----|-----------------|
+| `time_averaging_scripts` | `scripts/averaging` | `create_climo_files` (`create_TEM_files` optional) |
+| `regridding_scripts` | `scripts/regridding` | `regrid_and_vert_interp` |
+| `analysis_scripts` | `scripts/analysis` | `amwg_table` |
+| `plotting_scripts` | `scripts/plotting` | `global_mean_timeseries`, `global_latlon_map`, `global_latlon_vect_map`, `zonal_mean`, `meridional_mean`, `polar_map`, `cam_taylor_diagram`, `ozone_diagnostics`, `qbo` (`tape_recorder`, `tem` optional) |
+
+---
+
+## `diag_var_list` — variables to process
+
+A flat list of CAM variable names to diagnose. Notes:
+
+- **Aerosol column burdens** (`cb_*`), **surface fluxes** (`SF*`), and **optical
+  depths** (`AOD*`, `D550_*`) are *derived* — ADF auto-adds `PMID` and `T` when
+  any aerosol variable is requested.
+- **3-D variables** (`T`, `U`, `O3`, `RELHUM`, `CLOUD`, `OMEGA500`, …) carry a
+  vertical dim and are plotted on `plot_press_levels`.
+- If CVDP is run, include `PSL, TREFHT, TS, PRECT` (or `PRECC`+`PRECL`).
+- Commented lines at the end of the list (e.g. `SFSO2`, `WD_*`, `DF_*`, `sum_*`)
+  are examples/templates you can enable.
+
+---
+
+## Minimal working example (bare-bones)
+
+```yaml
+user: 'mvertens'
+case: 'n1850.ne16pg3_tn14.noresm3_0_beta21.476.2026-07-03'
+nick: 'beta21_ne16'
+
+diag_basic_info:
+    hist_str: cam.h0a
+    compare_obs: false
+    create_html: true
+    cam_regrid_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/tseries/regrid
+    cam_overwrite_regrid: false
+    cam_se_grid: ne16                     # ne16 | ne30 | (omit to skip regridding)
+    cam_se_weight_file_ne16: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc
+    cam_se_weight_file_ne30: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc
+    cam_diag_plot_loc: /nird/datalake/NS2345K/www/diagnostics/ADF/${user}
+    num_procs: 8
+    redo_plot: true
+
+diag_cam_climo:
+    cam_case_name: ${case}
+    case_nickname: ${nick}
+    cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_climo.cam_case_name}/atm/hist
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo
+    cam_ts_loc:    /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries_regridded
+    start_year: 960
+    end_year: 969
+    cam_ts_done: false
+    cam_overwrite_ts: false
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ conda activate npl
 
 On NIRD machine (login or ipcc node)
 ```
-conda activate /projects/NS9560K/diagnostics/ADF/envs/adf_v0.14
+conda activate /projects/NS9560K/diagnostics/ADF/envs/adf_v0.13
+or
+conda activate /nird/datalake/NS16000B/ADF-env/adf_v0.13
+
+Note: the conda environment can be updated, so check the ADF-env directory for the latest version.
 ```
 
 On a non-CISL or non-NIRD machine, you can create and activate the appropriate python enviroment using the `env/conda_environment.yaml` file like so:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module load conda
 conda activate npl
 ```
 
-On NIRD IPCC machine
+On NIRD machine (login or ipcc node)
 ```
 conda activate /projects/NS9560K/diagnostics/ADF/envs/adf_v0.14
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Finally, if you are interested in general (but non-supported) tools used by AMP 
 
 ## Required software environment
 
+### Python environment
 These diagnostics currently require Python version 3.6 or higher.  They also require the following non-standard python libraries/modules:
 
 - PyYAML
@@ -25,6 +26,7 @@ These diagnostics currently require Python version 3.6 or higher.  They also req
 - Matplotlib
 - Cartopy
 - GeoCAT
+- xESMF (needed if SE->lat/lon mapping will occur)
 
 If one wants to generate the "AMWG" model variable statistics table as well, then these additional python libraries are also needed:
 
@@ -36,24 +38,37 @@ On NCAR's CISL machines (cheyenne and casper), these can be loaded by running th
 module load conda
 conda activate npl
 ```
-If you are using conda on a non-CISL machine, then you can create and activate the appropriate python enviroment using the `env/conda_environment.yaml` file like so:
 
+On NIRD IPCC machine
+```
+conda activate /projects/NS9560K/diagnostics/ADF/envs/adf_v0.14
+```
+
+On a non-CISL or non-NIRD machine, you can create and activate the appropriate python enviroment using the `env/conda_environment.yaml` file like so:
 ```
 conda env create -f env/conda_environment.yaml
 conda activate adf_v1.0.0
 ```
 
-Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On the CISL machines this can be loaded by simply running:
+###  NetCDF Operator (NCO) suite
+The `ncrcat` NetCDF Operator (NCO) is also needed.
+- On the CISL machines this can be loaded by simply running:
 ```
 module load nco
 ``` 
-or on the CGD machines by simply running:
+- On the CGD machines by simply running:
 ```
 module load tool/nco
 ```
-on the command line.
+- On the NIRD machine run:
+```
+module load NCO/5.0.3-intel-2021b
+```
 
-Finally, if you also want to run the [Climate Variability Diagnostics Package](https://www.cesm.ucar.edu/working_groups/CVC/cvdp/) (CVDP) as part of the ADF then you'll also need NCL.  On the CISL machines this can be done using the command:
+### Climate Variability Diagnostics
+
+Finally, if you also want to run the [Climate Variability Diagnostics Package](https://www.cesm.ucar.edu/working_groups/CVC/cvdp/) (CVDP) as part of the ADF then you'll also need NCL.
+On the CISL machines this can be done using the command:
 ```
 module load ncl
 ```
@@ -65,8 +80,9 @@ on the command line.
 
 ## Running ADF diagnostics
 
-Detailed instructions for users and developers are availabe on this repository's [wiki](https://github.com/NCAR/ADF/wiki).
+A detailed summary of the input yaml file is provided in [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md).
 
+Detailed instructions for users and developers are availabe on this repository's [wiki](https://github.com/NCAR/ADF/wiki).
 
 To run an example of the ADF diagnostics, simply download this repo, setup your computing environment as described in the [Required software environment](https://github.com/NCAR/CAM_diagnostics/blob/main/README.md#required-software-environment) section above, modify the `config_cam_baseline_example.yaml` file (or create one of your own) to point to the relevant diretories and run:
 

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -1,392 +1,77 @@
-#==============================
-# config_amwg_default_plots.yaml
-
-# This config file contains the standard set of variables and plots used for
-# evaluating CAM simulations in the AMWG working group.
-
-#Currently, if one is on NCAR's Casper or
-#Cheyenne machine, then only the diagnostic output
-#paths are needed, at least to perform a quick test
-#run (these are indicated with "MUST EDIT" comments).
-#Running these diagnostics on a different machine,
-#or with a different, non-example simulation, will
-#require additional modifications.
-#
-#Config file Keywords:
-#--------------------
-#
-#1.  Using ${xxx} will substitute that text with the
-#    variable referenced by xxx. For example:
-#
-#    cam_case_name: cool_run
-#    cam_climo_loc: /some/where/${cam_case_name}
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/cool_run
-#
-#    Please note that currently this will only work if the
-#    variable only exists in one location in the file.
-#
-#2.  Using ${<top_level_section>.xxx} will do the same as
-#    keyword 1 above, but specifies which sub-section the
-#    variable is coming from, which is necessary for variables
-#    that are repeated in different subsections.  For example:
-#
-#    diag_basic_info:
-#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
-#
-#    diag_cam_climo:
-#      start_year: 1850
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/1850
-#
-#Finally, please note that for both 1 and 2 the keywords must be lowercase.
-#This is because future developments will hopefully use other keywords
-#that are uppercase. Also please avoid using periods (".") in variable
-#names, as this will likely cause issues with the current file parsing
-#system.
-#--------------------
-#
-##==============================
-#
-# This file doesn't (yet) read environment variables, so the user must
-# set this themselves. It is also a good idea to search the doc for 'user'
-# to see what default paths are being set for output/working files.
-#
-# Note that the string 'USER-NAME-NOT-SET' is used in the jupyter script
-# to check for a failure to customize
-#
 user: 'USER-NAME-NOT-SET'
 
-
-#This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
-
-    #Is this a model vs observations comparison?
-    #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
-
-    #Generate HTML website (assumed false if missing):
-    #Note:  The website files themselves will be located in the path
-    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
-    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
-    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
     create_html: true
-
-    #Location of observational datasets:
-    #Note: this only matters if "compare_obs" is true and the path
-    #isn't specified in the variable defaults file.
     obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
-
-    #Location where re-gridded and interpolated CAM climatology files are stored:
     cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
-
-    #Overwrite CAM re-gridded files?
-    #If false, or missing, then regridding will be skipped for regridded variables
-    #that already exist in "cam_regrid_loc":
     cam_overwrite_regrid: false
-
-    #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
-
-    #Location of ADF variable plotting defaults YAML file:
-    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file
-    #defaults_file: /some/path/to/defaults/file.yaml
-
-    #Vertical pressure levels (in hPa) on which to plot 3-D variables
-    #when using horizontal (e.g. lat/lon) map projections.
-    #If this config option is missing, then no 3-D variables will be plotted on
-    #horizontal maps.  Please note too that pressure levels must currently match
-    #what is available in the observations file in order to be plotted in a
-    #model vs obs run:
     plot_press_levels: [200,850]
-
-    #Longitude line on which to center all lat/lon maps.
-    #If this config option is missing then the central
-    #longitude will default to 180 degrees E.
     central_longitude: 180
-
-    #Number of processors on which to run the ADF.
-    #If this config variable isn't present then
-    #the ADF defaults to one processor.  Also, if
-    #you set it to "*" then it will default
-    #to all of the processors available on a
-    #single node/machine:
     num_procs: 8
-
-    #If set to true, then redo all plots even if they already exist.
-    #If set to false, then if a plot is found it will be skipped:
     redo_plot: false
 
-
-#This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not prsent, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM case (or CAM run name):
     cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.098
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM history (h0) files:
-    #Example test files
     cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
-
-    #Location of CAM climatologies (to be created and then used by this script)
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 10
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 14
-
-    #Do time series files exist?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files?
-    #WARNING:  This can take up a significant amount of space,
-       #          but will save processing time the next time
     cam_ts_save: true
-
-    #Overwrite time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-    #----------------------
-
-#This third set of variables provide info for the CAM baseline climatologies.
-#This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate cam baseline climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not present, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM baseline case:
     cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
-
-    #Baseline case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM baseline history (h0) files:
-    #Example test files
     cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
-
-    #Location of baseline CAM climatologies:
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 10
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 14
-
-    #Do time series files need to be generated?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files for baseline run?
-    #WARNING:  This can take up a significant amount of space:
     cam_ts_save: true
-
-    #Overwrite baseline time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-#This fourth set of variables provides settings for calling the Climate Variability
-# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
-# run in background mode, likely completing after the ADF has completed.
-# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
-# in the diag_var_list variable listing.
-# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
 diag_cvdp_info:
-
-    # Run the CVDP on the listed run(s)?
     cvdp_run: false
-
-    # CVDP code path, sets the location of the CVDP codebase
-    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  github location = https://github.com/NCAR/CVDP-ncl
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-
-    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
     cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
-
-    # tar up CVDP results?
     cvdp_tar: false
 
-# This set of variables provides settings for calling NOAA's
-# Model Diagnostic Task Force (MDTF) diagnostic package.
-# https://github.com/NOAA-GFDL/MDTF-diagnostics
-#
-# If mdtf_run: true, the MDTF will be set up and 
-# run in background mode, likely completing after the ADF has completed.
-#
-# WARNING: This currently only runs on CASPER (not derecho)
-#
-# The variables required depend on the diagnostics (PODs) selected. 
-# AMWG-developed PODS and their required variables:
-#   (Note that PRECT can be computed from PRECC & PRECL)
-#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
-#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
-#              (will use what is available)
-#  - Blocking (Rich Neale):  daily OMEGA500
-#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
-#
-# Many other diagnostics are available; see 
-# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
-
-#
 diag_mdtf_info:
-    # Run the MDTF on the model cases
     mdtf_run: false
-
-    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
-    mdtf_input_settings_filename : mdtf_input.json   
-
-    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
-    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
-
-    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
+    mdtf_input_settings_filename : mdtf_input.json
+    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf
     mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
     conda_root         : /glade/u/apps/opt/conda
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
+    MODEL_DATA_ROOT    : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model
+    pod_list           :  [ "MJO_suite" ]
 
-    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
-    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
-
-    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
-    pod_list      :  [ "MJO_suite" ]
-
-    # Intermediate/output file settings
-    make_variab_tar: false     # tar up MDTF results
-    save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
-
-    # Settings used in debugging:
-    verbose  : 3       # Log verbosity level.
-    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
-    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
-
-    # Settings that shouldn't change in ADF implementation for now
-    data_type           : single_run # single_run or multi_run (only works with single right now)
-    data_manager        : Local_File # Fetch data or it is local?
-    environment_manager : Conda      # Manage dependencies
-
-
-
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-#These variables below only matter if you are using
-#a non-standard method, or are adding your own
-#diagnostic scripts.
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-
-#Note:  If you want to pass arguments to a particular script, you can
-#do it like so (using the "averaging_example" script in this case):
-# - {create_climo_files: {kwargs: {clobber: true}}}
-
-#Name of time-averaging scripts being used to generate climatologies.
-#These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
-    #- create_TEM_files #To generate TEM files, please un-comment
 
-#Name of regridding scripts being used.
-#These scripts must be located in "scripts/regridding":
 regridding_scripts:
     - regrid_and_vert_interp
 
-#List of analysis scripts being used.
-#These scripts must be located in "scripts/analysis":
 analysis_scripts:
     - amwg_table
-    #- aerosol_gas_tables
 
-#List of plotting scripts being used.
-#These scripts must be located in "scripts/plotting":
 plotting_scripts:
     - global_latlon_map
     - global_latlon_vect_map
@@ -394,13 +79,7 @@ plotting_scripts:
     - polar_map
     - cam_taylor_diagram
     - ozone_diagnostics
-    #- tape_recorder
-    #- tem
-    #- regional_map_multicase #To use this please un-comment and fill-out
-                              #the "region_multicase" section below
 
-#List of CAM variables that will be processesd:
-#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
    - AODDUST
    - AODVIS
@@ -445,7 +124,8 @@ diag_var_list:
    - O3
 
 #<Add more variables here.>
-# MDTF recommended variables
+# MDTF (Model Diagnostics Task Force) recommended variables
+#    - FLUT
 #    - OMEGA
 #    - PRECT
 #    - PS
@@ -454,11 +134,13 @@ diag_var_list:
 #    - U850
 #    - V200
 #    - V850
-    
+
 # Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# for region_time_option - if calendar, will look for specified years, if zeroanchor
+#  will use a nyears starting from year_offset from the beginning of timeseries
 # region_multicase:
 #     region_spec: [slat, nlat, wlon, elon]
-#     region_time_option: <calendar | zeroanchor>  # If calendar, will look for specified years. If zeroanchor will use a nyears starting from year_offset from the beginning of timeseries
+#     region_time_option: <calendar | zeroanchor>
 #     region_start_year:
 #     region_end_year:
 #     region_nyear:
@@ -466,5 +148,3 @@ diag_var_list:
 #     region_month: <NULL means look for season>
 #     region_season: <NULL means use annual mean>
 #     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
-
-#END OF FILE

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -1,477 +1,90 @@
-#==============================
-#config_cam_baseline_example.yaml
-
-#This is the main CAM diagnostics config file
-#for doing comparisons of a CAM run against
-#another CAM run, or a CAM baseline simulation.
-
-#Currently, if one is on NCAR's Casper or
-#Cheyenne machine, then only the diagnostic output
-#paths are needed, at least to perform a quick test
-#run (these are indicated with "MUST EDIT" comments).
-#Running these diagnostics on a different machine,
-#or with a different, non-example simulation, will
-#require additional modifications.
-#
-#Config file Keywords:
-#--------------------
-#
-#1.  Using ${xxx} will substitute that text with the
-#    variable referenced by xxx. For example:
-#
-#    cam_case_name: cool_run
-#    cam_climo_loc: /some/where/${cam_case_name}
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/cool_run
-#
-#    Please note that currently this will only work if the
-#    variable only exists in one location in the file.
-#
-#2.  Using ${<top_level_section>.xxx} will do the same as
-#    keyword 1 above, but specifies which sub-section the
-#    variable is coming from, which is necessary for variables
-#    that are repeated in different subsections.  For example:
-#
-#    diag_basic_info:
-#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
-#
-#    diag_cam_climo:
-#      start_year: 1850
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/1850
-#
-#Finally, please note that for both 1 and 2 the keywords must be lowercase.
-#This is because future developments will hopefully use other keywords
-#that are uppercase. Also please avoid using periods (".") in variable
-#names, as this will likely cause issues with the current file parsing
-#system.
-#--------------------
-#
-##==============================
-#
-# This file doesn't (yet) read environment variables, so the user must
-# set this themselves. It is also a good idea to search the doc for 'user'
-# to see what default paths are being set for output/working files.
-#
-# Note that the string 'USER-NAME-NOT-SET' is used in the jupyter script
-# to check for a failure to customize
-#
 user: 'USER-NAME-NOT-SET'
 
-
-#This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
-
-    #Is this a model vs observations comparison?
-    #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
-
-    #Generate HTML website (assumed false if missing):
-    #Note:  The website files themselves will be located in the path
-    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
-    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
-    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
     create_html: true
-
-    #Location of observational datasets:
-    #Note: this only matters if "compare_obs" is true and the path
-    #isn't specified in the variable defaults file.
     obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
-
-    #Location where re-gridded and interpolated CAM climatology files are stored:
     cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
-
-    #Overwrite CAM re-gridded files?
-    #If false, or missing, then regridding will be skipped for regridded variables
-    #that already exist in "cam_regrid_loc":
     cam_overwrite_regrid: false
-
-    #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
-
-    #Location of ADF variable plotting defaults YAML file:
-    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file
-    #defaults_file: /some/path/to/defaults/file.yaml
-
-    #Vertical pressure levels (in hPa) on which to plot 3-D variables
-    #when using horizontal (e.g. lat/lon) map projections.
-    #If this config option is missing, then no 3-D variables will be plotted on
-    #horizontal maps.  Please note too that pressure levels must currently match
-    #what is available in the observations file in order to be plotted in a
-    #model vs obs run:
     plot_press_levels: [200,850]
-
-    #Longitude line on which to center all lat/lon maps.
-    #If this config option is missing then the central
-    #longitude will default to 180 degrees E.
     central_longitude: 180
-
-    #Number of processors on which to run the ADF.
-    #If this config variable isn't present then
-    #the ADF defaults to one processor.  Also, if
-    #you set it to "*" then it will default
-    #to all of the processors available on a
-    #single node/machine:
     num_procs: 8
-
-    #If set to true, then redo all plots even if they already exist.
-    #If set to false, then if a plot is found it will be skipped:
     redo_plot: false
 
-#This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not prsent, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM case (or CAM run name):
     cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.098
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM history (h0) files:
-    #Example test files
     cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
-
-    #Location of CAM climatologies (to be created and then used by this script)
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 10
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 14
-
-    #Do time series files exist?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files?
-    #WARNING:  This can take up a significant amount of space,
-       #          but will save processing time the next time
     cam_ts_save: true
-
-    #Overwrite time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-    #----------------------
-
-    #You can alternatively provide a list of cases, which will make the ADF
-    #apply the same diagnostics to each case separately in a single ADF session.
-    #All of the config variables below show how it is done, and are the only ones
-    #that need to be lists.  This also automatically enables the generation of
-    #a "main_website" in "cam_diag_plot_loc" that brings all of the different cases
-    #together under a single website.
-
-    #Also please note that config keywords cannot currently be used in list mode.
-
-    #cam_case_name:
-    #    - b.e23_alpha17f.BLT1850.ne30_t232.098
-    #    - b.e23_alpha17f.BLT1850.ne30_t232.095
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    #case_nickname:
-    #    - cool nickname
-    #    - cool nickname 2
-
-    #calc_cam_climo:
-    #    - true
-    #    - true
-
-    #cam_overwrite_climo:
-    #    - false
-    #    - false
-
-    #cam_hist_loc:
-    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.098
-    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.095
-
-    #cam_climo_loc:
-    #    - /some/where/you/want/to/have/climo_files/ #MUST EDIT!
-    #    - /the/same/or/some/other/climo/files/location
-
-    #start_year:
-    #    - 10
-    #    - 10
-
-    #end_year:
-    #    - 14
-    #    - 14
-
-    #cam_ts_done:
-    #    - false
-    #    - false
-
-    #cam_ts_save:
-    #    - true
-    #    - true
-
-    #cam_overwrite_ts:
-    #    - false
-    #    - false
-
-    #cam_ts_loc:
-    #    - /some/where/you/want/to/have/time_series_files
-    #    - /same/or/different/place/you/want/files
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
-    #tem_hist_str:
-    #    - cam.h4
-    #    - cam.h#
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    #cam_tem_loc:
-    #    - /some/where/you/want/to/have/TEM_files/
-    #    - /same/or/different/place/you/want/TEM_files/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
-    #overwrite_tem:
-    #    - false
-    #    - true
-
-    #----------------------
-
-
-#This third set of variables provide info for the CAM baseline climatologies.
-#This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate cam baseline climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not present, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM baseline case:
     cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
-
-    #Baseline case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM baseline history (h0) files:
-    #Example test files
     cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
-
-    #Location of baseline CAM climatologies:
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 10
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 14
-
-    #Do time series files need to be generated?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files for baseline run?
-    #WARNING:  This can take up a significant amount of space:
     cam_ts_save: true
-
-    #Overwrite baseline time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-
-#This fourth set of variables provides settings for calling the Climate Variability
-# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
-# run in background mode, likely completing after the ADF has completed.
-# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
-# in the diag_var_list variable listing.
-# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
 diag_cvdp_info:
-
-    # Run the CVDP on the listed run(s)?
     cvdp_run: false
-
-    # CVDP code path, sets the location of the CVDP codebase
-    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  github location = https://github.com/NCAR/CVDP-ncl
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-
-    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
     cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
-
-    # tar up CVDP results?
     cvdp_tar: false
 
-# This set of variables provides settings for calling NOAA's
-# Model Diagnostic Task Force (MDTF) diagnostic package.
-# https://github.com/NOAA-GFDL/MDTF-diagnostics
-#
-# If mdtf_run: true, the MDTF will be set up and 
-# run in background mode, likely completing after the ADF has completed.
-#
-# WARNING: This currently only runs on CASPER (not derecho)
-#
-# The variables required depend on the diagnostics (PODs) selected. 
-# AMWG-developed PODS and their required variables:
-#   (Note that PRECT can be computed from PRECC & PRECL)
-#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
-#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
-#              (will use what is available)
-#  - Blocking (Rich Neale):  daily OMEGA500
-#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
-#
-# Many other diagnostics are available; see 
-# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
-
-#
 diag_mdtf_info:
-    # Run the MDTF on the model cases
     mdtf_run: false
-
-    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
-    mdtf_input_settings_filename : mdtf_input.json   
-
-    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
-    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
-
-    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
+    mdtf_input_settings_filename : mdtf_input.json
+    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf
     mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
     conda_root         : /glade/u/apps/opt/conda
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
+    MODEL_DATA_ROOT    : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model
+    pod_list           :  [ "MJO_suite" ]
 
-    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
-    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
-
-    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
-    pod_list      :  [ "MJO_suite" ]
-
-    # Intermediate/output file settings
-    make_variab_tar: false     # tar up MDTF results
-    save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
-
-    # Settings used in debugging:
-    verbose  : 3       # Log verbosity level.
-    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
-    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
-
-    # Settings that shouldn't change in ADF implementation for now
-    data_type           : single_run # single_run or multi_run (only works with single right now)
-    data_manager        : Local_File # Fetch data or it is local?
-    environment_manager : Conda      # Manage dependencies
-
-
-
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-#These variables below only matter if you are using
-#a non-standard method, or are adding your own
-#diagnostic scripts.
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-
-#Note:  If you want to pass arguments to a particular script, you can
-#do it like so (using the "averaging_example" script in this case):
-# - {create_climo_files: {kwargs: {clobber: true}}}
-
-#Name of time-averaging scripts being used to generate climatologies.
-#These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
-    #- create_TEM_files #To generate TEM files, please un-comment
 
-#Name of regridding scripts being used.
-#These scripts must be located in "scripts/regridding":
 regridding_scripts:
     - regrid_and_vert_interp
 
-#List of analysis scripts being used.
-#These scripts must be located in "scripts/analysis":
 analysis_scripts:
     - amwg_table
-    #- aerosol_gas_tables
+    - global_latlon_map
+  # - global_latlon_vect_map
+  # - zonal_mean
+  # - meridional_mean
+  # - polar_map
+  # - cam_taylor_diagram
+  # - qbo
+  # - ozone_diagnostics
+    - enso_comparison_plots
+  # - tape_recorder
+  # - tem
+  # - regional_map_multicase #To use this please un-comment and fill-out
+                             #the "region_multicase" section below
 
-#List of plotting scripts being used.
-#These scripts must be located in "scripts/plotting":
 plotting_scripts:
     - global_latlon_map
     - global_latlon_vect_map
@@ -482,13 +95,7 @@ plotting_scripts:
     - qbo
     - ozone_diagnostics
     - MOPITT
-    #- tape_recorder
-    #- tem
-    #- regional_map_multicase #To use this please un-comment and fill-out
-                              #the "region_multicase" section below
 
-#List of CAM variables that will be processesd:
-#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
     - SWCF
     - LWCF
@@ -510,7 +117,7 @@ diag_var_list:
     - CO
 
 #<Add more variables here.>
-# MDTF recommended variables
+# MDTF (Model Diagnostics Task Force) recommended variables
 #    - FLUT
 #    - OMEGA500
 #    - PRECT
@@ -520,11 +127,13 @@ diag_var_list:
 #    - U850
 #    - V200
 #    - V850
-    
+
 # Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# for region_time_option - if calendar, will look for specified years, if zeroanchor
+#  will use a nyears starting from year_offset from the beginning of timeseries
 # region_multicase:
 #     region_spec: [slat, nlat, wlon, elon]
-#     region_time_option: <calendar | zeroanchor>  # If calendar, will look for specified years. If zeroanchor will use a nyears starting from year_offset from the beginning of timeseries
+#     region_time_option: <calendar | zeroanchor>
 #     region_start_year:
 #     region_end_year:
 #     region_nyear:
@@ -532,5 +141,3 @@ diag_var_list:
 #     region_month: <NULL means look for season>
 #     region_season: <NULL means use annual mean>
 #     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
-
-#END OF FILE

--- a/config_cam_baseline_example_testENSO.yaml
+++ b/config_cam_baseline_example_testENSO.yaml
@@ -1,496 +1,75 @@
-#==============================
-#config_cam_baseline_example.yaml
-
-#This is the main CAM diagnostics config file
-#for doing comparisons of a CAM run against
-#another CAM run, or a CAM baseline simulation.
-
-#Currently, if one is on NCAR's Casper or
-#Cheyenne machine, then only the diagnostic output
-#paths are needed, at least to perform a quick test
-#run (these are indicated with "MUST EDIT" comments).
-#Running these diagnostics on a different machine,
-#or with a different, non-example simulation, will
-#require additional modifications.
-#
-#Config file Keywords:
-#--------------------
-#
-#1.  Using ${xxx} will substitute that text with the
-#    variable referenced by xxx. For example:
-#
-#    cam_case_name: cool_run
-#    cam_climo_loc: /some/where/${cam_case_name}
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/cool_run
-#
-#    Please note that currently this will only work if the
-#    variable only exists in one location in the file.
-#
-#2.  Using ${<top_level_section>.xxx} will do the same as
-#    keyword 1 above, but specifies which sub-section the
-#    variable is coming from, which is necessary for variables
-#    that are repeated in different subsections.  For example:
-#
-#    diag_basic_info:
-#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
-#
-#    diag_cam_climo:
-#      start_year: 1850
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/1850
-#
-#Finally, please note that for both 1 and 2 the keywords must be lowercase.
-#This is because future developments will hopefully use other keywords
-#that are uppercase. Also please avoid using periods (".") in variable
-#names, as this will likely cause issues with the current file parsing
-#system.
-#--------------------
-#
-##==============================
-#
-# This file doesn't (yet) read environment variables, so the user must
-# set this themselves. It is also a good idea to search the doc for 'user'
-# to see what default paths are being set for output/working files.
-#
-# Note that the string 'USER-NAME-NOT-SET' is used in the jupyter script
-# to check for a failure to customize
-#
 user: 'mdfowler'
 
-
-#This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
-
-    #Is this a model vs observations comparison?
-    #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
-
-    #Generate HTML website (assumed false if missing):
-    #Note:  The website files themselves will be located in the path
-    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
-    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
-    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
     create_html: true
-
-    #Location of observational datasets:
-    #Note: this only matters if "compare_obs" is true and the path
-    #isn't specified in the variable defaults file.
     obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
-
-    #Location where re-gridded and interpolated CAM climatology files are stored:
     cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
-
-    #Overwrite CAM re-gridded files?
-    #If false, or missing, then regridding will be skipped for regridded variables
-    #that already exist in "cam_regrid_loc":
     cam_overwrite_regrid: false
-
-    #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
-
-    #Location of ADF variable plotting defaults YAML file:
-    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file
-    #defaults_file: /some/path/to/defaults/file.yaml
-
-    #Vertical pressure levels (in hPa) on which to plot 3-D variables
-    #when using horizontal (e.g. lat/lon) map projections.
-    #If this config option is missing, then no 3-D variables will be plotted on
-    #horizontal maps.  Please note too that pressure levels must currently match
-    #what is available in the observations file in order to be plotted in a
-    #model vs obs run:
     plot_press_levels: [200,850]
-
-    #Longitude line on which to center all lat/lon maps.
-    #If this config option is missing then the central
-    #longitude will default to 180 degrees E.
     central_longitude: 180
-
-    #Number of processors on which to run the ADF.
-    #If this config variable isn't present then
-    #the ADF defaults to one processor.  Also, if
-    #you set it to "*" then it will default
-    #to all of the processors available on a
-    #single node/machine:
     num_procs: 8
-
-    #If set to true, then redo all plots even if they already exist.
-    #If set to false, then if a plot is found it will be skipped:
     redo_plot: true
 
-#This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not prsent, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM case (or CAM run name):
     cam_case_name: b.e30_alpha06b.B1850C_LTso.ne30_t232_wgx3.132
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
     case_nickname: '132'
-
-    #Location of CAM history (h0) files:
-    #Example test files
-    # cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
     cam_hist_loc: /glade/derecho/scratch/hannay/archive//b.e30_alpha06b.B1850C_LTso.ne30_t232_wgx3.132/atm/hist
-
-    #Location of CAM climatologies (to be created and then used by this script)
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 2
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 44
-
-    #Do time series files exist?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files?
-    #WARNING:  This can take up a significant amount of space,
-       #          but will save processing time the next time
     cam_ts_save: true
-
-    #Overwrite time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-    #----------------------
-
-    #You can alternatively provide a list of cases, which will make the ADF
-    #apply the same diagnostics to each case separately in a single ADF session.
-    #All of the config variables below show how it is done, and are the only ones
-    #that need to be lists.  This also automatically enables the generation of
-    #a "main_website" in "cam_diag_plot_loc" that brings all of the different cases
-    #together under a single website.
-
-    #Also please note that config keywords cannot currently be used in list mode.
-
-    #cam_case_name:
-    #    - b.e23_alpha17f.BLT1850.ne30_t232.098
-    #    - b.e23_alpha17f.BLT1850.ne30_t232.095
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    #case_nickname:
-    #    - cool nickname
-    #    - cool nickname 2
-
-    #calc_cam_climo:
-    #    - true
-    #    - true
-
-    #cam_overwrite_climo:
-    #    - false
-    #    - false
-
-    #cam_hist_loc:
-    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.098
-    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.095
-
-    #cam_climo_loc:
-    #    - /some/where/you/want/to/have/climo_files/ #MUST EDIT!
-    #    - /the/same/or/some/other/climo/files/location
-
-    #start_year:
-    #    - 10
-    #    - 10
-
-    #end_year:
-    #    - 14
-    #    - 14
-
-    #cam_ts_done:
-    #    - false
-    #    - false
-
-    #cam_ts_save:
-    #    - true
-    #    - true
-
-    #cam_overwrite_ts:
-    #    - false
-    #    - false
-
-    #cam_ts_loc:
-    #    - /some/where/you/want/to/have/time_series_files
-    #    - /same/or/different/place/you/want/files
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
-    #tem_hist_str:
-    #    - cam.h4
-    #    - cam.h#
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    #cam_tem_loc:
-    #    - /some/where/you/want/to/have/TEM_files/
-    #    - /same/or/different/place/you/want/TEM_files/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
-    #overwrite_tem:
-    #    - false
-    #    - true
-
-    #----------------------
-
-
-#This third set of variables provide info for the CAM baseline climatologies.
-#This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate cam baseline climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not present, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM baseline case:
     cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
-
-    #Baseline case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM baseline history (h0) files:
-    #Example test files
     cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
-
-    #Location of baseline CAM climatologies:
     cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
     start_year: 10
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
     end_year: 14
-
-    #Do time series files need to be generated?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
     cam_ts_done: false
-
-    #Save interim time series files for baseline run?
-    #WARNING:  This can take up a significant amount of space:
     cam_ts_save: true
-
-    #Overwrite baseline time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
     cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-
-#This fourth set of variables provides settings for calling the Climate Variability
-# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
-# run in background mode, likely completing after the ADF has completed.
-# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
-# in the diag_var_list variable listing.
-# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
 diag_cvdp_info:
-
-    # Run the CVDP on the listed run(s)?
     cvdp_run: false
-
-    # CVDP code path, sets the location of the CVDP codebase
-    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  github location = https://github.com/NCAR/CVDP-ncl
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-
-    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
     cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
-
-    # tar up CVDP results?
     cvdp_tar: false
 
-# This set of variables provides settings for calling NOAA's
-# Model Diagnostic Task Force (MDTF) diagnostic package.
-# https://github.com/NOAA-GFDL/MDTF-diagnostics
-#
-# If mdtf_run: true, the MDTF will be set up and 
-# run in background mode, likely completing after the ADF has completed.
-#
-# WARNING: This currently only runs on CASPER (not derecho)
-#
-# The variables required depend on the diagnostics (PODs) selected. 
-# AMWG-developed PODS and their required variables:
-#   (Note that PRECT can be computed from PRECC & PRECL)
-#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
-#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
-#              (will use what is available)
-#  - Blocking (Rich Neale):  daily OMEGA500
-#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
-#
-# Many other diagnostics are available; see 
-# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
-
-#
 diag_mdtf_info:
-    # Run the MDTF on the model cases
     mdtf_run: false
 
-    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
-    mdtf_input_settings_filename : mdtf_input.json   
-
-    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
-    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
-
-    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
-    mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
-    conda_root         : /glade/u/apps/opt/conda
-    conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
-    OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
-
-    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
-    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
-
-    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
-    pod_list      :  [ "MJO_suite" ]
-
-    # Intermediate/output file settings
-    make_variab_tar: false     # tar up MDTF results
-    save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
-
-    # Settings used in debugging:
-    verbose  : 3       # Log verbosity level.
-    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
-    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
-
-    # Settings that shouldn't change in ADF implementation for now
-    data_type           : single_run # single_run or multi_run (only works with single right now)
-    data_manager        : Local_File # Fetch data or it is local?
-    environment_manager : Conda      # Manage dependencies
-
-
-
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-#These variables below only matter if you are using
-#a non-standard method, or are adding your own
-#diagnostic scripts.
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-
-#Note:  If you want to pass arguments to a particular script, you can
-#do it like so (using the "averaging_example" script in this case):
-# - {create_climo_files: {kwargs: {clobber: true}}}
-
-#Name of time-averaging scripts being used to generate climatologies.
-#These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
-    #- create_TEM_files #To generate TEM files, please un-comment
 
-#Name of regridding scripts being used.
-#These scripts must be located in "scripts/regridding":
 regridding_scripts:
     - regrid_and_vert_interp
 
-#List of analysis scripts being used.
-#These scripts must be located in "scripts/analysis":
 analysis_scripts:
     - amwg_table
     - ENSO_acrossRuns
-    #- aerosol_gas_tables
 
-#List of plotting scripts being used.
-#These scripts must be located in "scripts/plotting":
 plotting_scripts:
     - global_latlon_map
-    # - global_latlon_vect_map
-    # - zonal_mean
-    # - meridional_mean
-    # - polar_map
-    # - cam_taylor_diagram
-    # - qbo
-    # - ozone_diagnostics
     - enso_comparison_plots
-    #- tape_recorder
-    #- tem
-    #- regional_map_multicase #To use this please un-comment and fill-out
-                              #the "region_multicase" section below
 
-#List of CAM variables that will be processesd:
-#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
     - SWCF
     - LWCF
@@ -510,28 +89,5 @@ diag_var_list:
     - LANDFRAC
     - O3
 
-#<Add more variables here.>
-# MDTF recommended variables
-#    - FLUT
-#    - OMEGA500
-#    - PRECT
-#    - PS
-#    - PSL
-#    - U200
-#    - U850
-#    - V200
-#    - V850
     
-# Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
-# region_multicase:
-#     region_spec: [slat, nlat, wlon, elon]
-#     region_time_option: <calendar | zeroanchor>  # If calendar, will look for specified years. If zeroanchor will use a nyears starting from year_offset from the beginning of timeseries
-#     region_start_year:
-#     region_end_year:
-#     region_nyear:
-#     region_year_offset:
-#     region_month: <NULL means look for season>
-#     region_season: <NULL means use annual mean>
-#     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
 
-#END OF FILE

--- a/config_noresm_default.yaml
+++ b/config_noresm_default.yaml
@@ -99,6 +99,16 @@ diag_basic_info:
     #that already exist in "cam_regrid_loc":
     cam_overwrite_regrid: false
 
+    #Spectral-element (SE) atmosphere grid of the CAM case: ne16 or ne30.
+    #Used to select the SE -> lat/lon ESMF weight file below.  Only needed for
+    #native spectral-element (ncol) output; ignored for lat/lon output.
+    cam_se_grid: ne30
+
+    #ESMF weight (map) files for regridding native SE (ncol) output to lat/lon,
+    #one per SE grid.  The file matching "cam_se_grid" is used.
+    cam_se_weight_file_ne16: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc
+    cam_se_weight_file_ne30: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc
+
     #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /nird/datalake/NS2345K/www/diagnostics/ADF/${user}
 

--- a/config_noresm_default.yaml
+++ b/config_noresm_default.yaml
@@ -1,435 +1,83 @@
-#==============================
-#config_noresm_default.yaml
-# modified from config_amwg_default_plots.yaml
+user: 'mvertens'
+case: 'n1850.ne16pg3_tn14.noresm3_0_beta21.476.2026-07-03'
+nick: 'noresm3_ne30_beta21-run476'
+case_base: 'n1850.ne16pg3_tn14.noresm3_0_beta21.i478.2026-07-06'
+nick_base: 'noresm3_ne30_beta21-run478'
 
-# This config file contains the standard set of variables and plots used for
-# evaluating CAM simulations in the AMWG working group.
-
-#Currently, if one is on NCAR's Casper or
-#Cheyenne machine, then only the diagnostic output
-#paths are needed, at least to perform a quick test
-#run (these are indicated with "MUST EDIT" comments).
-#Running these diagnostics on a different machine,
-#or with a different, non-example simulation, will
-#require additional modifications.
-#
-# On sigma2 NIRD, please see the discussion on github
-# https://github.com/NorESMhub/noresm3_dev_simulations/discussions/17
-# for details
-#
-#Config file Keywords:
-#--------------------
-#
-#1.  Using ${xxx} will substitute that text with the
-#    variable referenced by xxx. For example:
-#
-#    cam_case_name: cool_run
-#    cam_climo_loc: /some/where/${cam_case_name}
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/cool_run
-#
-#    Please note that currently this will only work if the
-#    variable only exists in one location in the file.
-#
-#2.  Using ${<top_level_section>.xxx} will do the same as
-#    keyword 1 above, but specifies which sub-section the
-#    variable is coming from, which is necessary for variables
-#    that are repeated in different subsections.  For example:
-#
-#    diag_basic_info:
-#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
-#
-#    diag_cam_climo:
-#      start_year: 1850
-#
-#    will set "cam_climo_loc" in the diagnostics package to:
-#    /some/where/1850
-#
-#Finally, please note that for both 1 and 2 the keywords must be lowercase.
-#This is because future developments will hopefully use other keywords
-#that are uppercase. Also please avoid using periods (".") in variable
-#names, as this will likely cause issues with the current file parsing
-#system.
-#--------------------
-user: 'USER-NAME-NOT-SET'
-#
-##==============================
-#
-# This file doesn't (yet) read environment variables, so the user must
-# set this themselves. It is also a good idea to search the doc for 'user'
-# to see what default paths are being set for output/working files.
-#
-# Note that the string 'USER-NAME-NOT-SET' is used in the jupyter script
-# to check for a failure to customize
-#
-
-#-------------------------------------------------------------------------------------
-#This first set of variables specify basic info used by all diagnostic runs:
-#-------------------------------------------------------------------------------------
 diag_basic_info:
-
-    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries
-    # Leave off trailing '.'
-    #Default: cam.h0a
     hist_str: cam.h0a
-
-    #Is this a model vs observations comparison?
-    #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
-
-    #Generate HTML website (assumed false if missing):
-    #Note:  The website files themselves will be located in the path
-    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
-    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
-    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
     create_html: true
-
-    #Location of observational datasets:
-    #Note: this only matters if "compare_obs" is true and the path
-    #isn't specified in the variable defaults file.
     obs_data_loc: /nird/datalake/NS16000B/ADF-obs
-
-    #Location where re-gridded and interpolated CAM climatology files are stored:
     cam_regrid_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/tseries/regrid
-
-    #Overwrite CAM re-gridded files?
-    #If false, or missing, then regridding will be skipped for regridded variables
-    #that already exist in "cam_regrid_loc":
     cam_overwrite_regrid: false
-
-    #Spectral-element (SE) atmosphere grid of the CAM case: ne16 or ne30.
-    #Used to select the SE -> lat/lon ESMF weight file below.  Only needed for
-    #native spectral-element (ncol) output; ignored for lat/lon output.
-    cam_se_grid: ne30
-
-    #ESMF weight (map) files for regridding native SE (ncol) output to lat/lon,
-    #one per SE grid.  The file matching "cam_se_grid" is used.
+    cam_se_grid: ne16
     cam_se_weight_file_ne16: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc
     cam_se_weight_file_ne30: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc
-
-    #Location where diagnostic plots are stored:
-    cam_diag_plot_loc: /nird/datalake/NS2345K/www/diagnostics/ADF/${user}
-
-    #Location of ADF variable plotting defaults YAML file:
-    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file
-    #defaults_file: /some/path/to/defaults/file.yaml
-
-    #Vertical pressure levels (in hPa) on which to plot 3-D variables
-    #when using horizontal (e.g. lat/lon) map projections.
-    #If this config option is missing, then no 3-D variables will be plotted on
-    #horizontal maps.  Please note too that pressure levels must currently match
-    #what is available in the observations file in order to be plotted in a
-    #model vs obs run:
+    cam_diag_plot_loc: /nird/datalake/NS9560K/www/diagnostics/noresm/${user}/${case}/ADF_regridded
     plot_press_levels: [200,500,850]
-
-    #Longitude line on which to center all lat/lon maps.
-    #If this config option is missing then the central
-    #longitude will default to 180 degrees E.
     central_longitude: 180
-
-    #Number of processors on which to run the ADF.
-    #If this config variable isn't present then
-    #the ADF defaults to one processor.  Also, if
-    #you set it to "*" then it will default
-    #to all of the processors available on a
-    #single node/machine:
     num_procs: 8
-
-    #If set to true, then redo all plots even if they already exist.
-    #If set to false, then if a plot is found it will be skipped:
     redo_plot: true
 
-#-------------------------------------------------------------------------------------
-#This second set of variables provides info for the CAM simulation(s) being diagnosed:
-#-------------------------------------------------------------------------------------
 diag_cam_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not prsent, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM case (or CAM run name):
-    cam_case_name: n1850.ne30_tn14.hybrid_fatessp.20241219
-
-    #Case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: #cool nickname
-
-    #Location of CAM history (h0a) files:
-    #Example test files
+    cam_case_name: ${case}
+    case_nickname: ${nick}
     cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_climo.cam_case_name}/atm/hist
-    
-    #Location of CAM climatologies (to be created and then used by this script)
-    cam_climo_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
-    start_year: 100
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
-    end_year: 110
-    
-    #Do time series files exist?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo/s${diag_cam_climo.start_year}-e${diag_cam_climo.end_year}
+    start_year: 960
+    end_year: 969
     cam_ts_done: false
-
-    #Save interim time series files?
-    #WARNING:  This can take up a significant amount of space,
-    #          but will save processing time the next time
     cam_ts_save: true
-
-    #Overwrite time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
-    cam_ts_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/tseries
-                    
-#-------------------------------------------------------------------------------------
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries_regridded/s${diag_cam_climo.start_year}-e${diag_cam_climo.end_year}
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
     overwrite_tem: false
 
-    #----------------------
-
-#This third set of variables provide info for the CAM baseline climatologies.
-#-------------------------------------------------------------------------------------
-#This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
-
-    # History file list of strings to match
-    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
-    # Only affects timeseries as everything else uses the created timeseries 
-    # Default: 
     hist_str: cam.h0a
-
-    #Calculate cam baseline climatologies?
-    #If false, the climatology files will not be created:
     calc_cam_climo: true
-
-    #Overwrite CAM climatology files?
-    #If false, or not present, then already existing climatology files will be skipped:
     cam_overwrite_climo: false
-
-    #Name of CAM baseline case:
-    cam_case_name: n1850.ne30_tn14.hybrid_fatessp.20241204
-
-    #Baseline case nickname
-    #NOTE: if nickname starts with '0' - nickname must be in quotes!
-    # ie '026a' as opposed to 026a
-    #If missing or left blank, will default to cam_case_name
-    case_nickname: 
-
-    #Location of CAM baseline history (h0a) files:
-    #Example test files
+    cam_case_name: ${case_base}
+    case_nickname: ${nick_base}
     cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_baseline_climo.cam_case_name}/atm/hist
-
-    #Location of baseline CAM climatologies:
-    cam_climo_loc: /scratch/${user}/noresm3/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo
-
-    #model year when time series files should start:
-    #Note:  Leaving this entry blank will make time series
-    #       start at earliest available year.
-    start_year: 52
-
-    #model year when time series files should end:
-    #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
-    end_year: 71
-
-    #Do time series files need to be generated?
-    #If True, then diagnostics assumes that model files are already time series.
-    #If False, or if simply not present, then diagnostics will attempt to create
-    #time series files from history (time-slice) files:
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo/s${diag_cam_baseline_climo.start_year}-e${diag_cam_baseline_climo.end_year}
+    start_year: 960
+    end_year: 969
     cam_ts_done: false
-
-    #Save interim time series files for baseline run?
-    #WARNING:  This can take up a significant amount of space:
-    cam_ts_save: true
-
-    #Overwrite baseline time series files, if found?
-    #If set to false, then time series creation will be skipped if files are found:
+    cam_ts_save: false
     cam_overwrite_ts: false
-
-    #Location where time series files are (or will be) stored:
-    cam_ts_loc: /scratch/${user}/diagnostics/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/tseries
-
-    #TEM diagnostics
-    #---------------
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/tseries_regridded/s${diag_cam_baseline_climo.start_year}-e${diag_cam_baseline_climo.end_year}
     tem_hist_str: cam.h4
-
-    #Location where TEM files are stored:
-    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    cam_tem_loc: /scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
+    cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/tem/
     overwrite_tem: false
 
-#-------------------------------------------------------------------------------------
-#This fourth set of variables provides settings for calling the Climate Variability
-#-------------------------------------------------------------------------------------
-# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
-# run in background mode, likely completing after the ADF has completed.
-# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
-# in the diag_var_list variable listing.
-# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
 diag_cvdp_info:
-
-    # Run the CVDP on the listed run(s)?
     cvdp_run: false
 
-    # CVDP code path, sets the location of the CVDP codebase
-    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-    #  github location = https://github.com/NCAR/CVDP-ncl
-    cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
-
-    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
-    cvdp_loc: /glade/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
-
-    # tar up CVDP results?
-    cvdp_tar: false
-
-# This set of variables provides settings for calling NOAA's
-# Model Diagnostic Task Force (MDTF) diagnostic package.
-# https://github.com/NOAA-GFDL/MDTF-diagnostics
-#
-# If mdtf_run: true, the MDTF will be set up and 
-# run in background mode, likely completing after the ADF has completed.
-#
-# WARNING: This currently only runs on CASPER (not derecho)
-#
-# The variables required depend on the diagnostics (PODs) selected. 
-# AMWG-developed PODS and their required variables:
-#   (Note that PRECT can be computed from PRECC & PRECL)
-#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
-#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
-#              (will use what is available)
-#  - Blocking (Rich Neale):  daily OMEGA500
-#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
-#
-# Many other diagnostics are available; see 
-# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
-
-#
 diag_mdtf_info:
-    # Run the MDTF on the model cases
     mdtf_run: false
 
-    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
-    mdtf_input_settings_filename : mdtf_input.json   
-
-    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
-    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
-
-    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
-    mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
-    conda_root         : /glade/u/apps/opt/conda
-    conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
-    OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
-
-    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
-    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
-
-    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
-    pod_list      :  [ "MJO_suite" ]
-
-    # Intermediate/output file settings
-    make_variab_tar: false     # tar up MDTF results
-    save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
-
-    # Settings used in debugging:
-    verbose  : 3       # Log verbosity level.
-    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
-    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
-
-    # Settings that shouldn't change in ADF implementation for now
-    data_type           : single_run # single_run or multi_run (only works with single right now)
-    data_manager        : Local_File # Fetch data or it is local?
-    environment_manager : Conda      # Manage dependencies
-
-
-
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-#These variables below only matter if you are using
-#a non-standard method, or are adding your own
-#diagnostic scripts.
-#+++++++++++++++++++++++++++++++++++++++++++++++++++
-
-#Note:  If you want to pass arguments to a particular script, you can
-#do it like so (using the "averaging_example" script in this case):
-# - {create_climo_files: {kwargs: {clobber: true}}}
-
-#Name of time-averaging scripts being used to generate climatologies.
-#These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
-    - {create_climo_files: {kwargs: {clobber: false}}}
-    #- create_TEM_files #To generate TEM files, please un-comment
+    - create_climo_files
 
-#Name of regridding scripts being used.
-#These scripts must be located in "scripts/regridding":
 regridding_scripts:
     - regrid_and_vert_interp
 
-#List of analysis scripts being used.
-#These scripts must be located in "scripts/analysis":
 analysis_scripts:
     - amwg_table
 
-#List of plotting scripts being used.
-#These scripts must be located in "scripts/plotting":
 plotting_scripts:
     - global_mean_timeseries
     - global_latlon_map
-    - global_latlon_vect_map
     - zonal_mean
     - meridional_mean
-    - polar_map
-    - cam_taylor_diagram
-    - ozone_diagnostics
-    - qbo
-   #- tape_recorder
-   #- tem #To plot TEM, please un-comment fill-out the "tem_info" section below
 
-#List of CAM variables that will be processesd:
-#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
-    - AODDUST
     - AODVIS
     - cb_SULFATE
     - cb_isoprene
@@ -444,8 +92,6 @@ diag_var_list:
     - SFmonoterp
     - SFisoprene
     - SFSS
-    - SFDUST
-    - SFSOA
     - SFSO4
     - SFSO2_net
     - SFOM
@@ -454,11 +100,6 @@ diag_var_list:
     - SFH2O2
     - SFH2SO4
     - cb_SO2
-    - D550_BC
-    - D550_DU
-    - D550_POM
-    - D550_SO4
-    - D550_SS
     - CLDHGH
     - CLDICE
     - CLDLIQ
@@ -475,7 +116,6 @@ diag_var_list:
     - FSNTC
     - LHFLX
     - LWCF
-    - OMEGA500
     - PBLH
     - PRECT
     - PS
@@ -483,7 +123,6 @@ diag_var_list:
     - QFLX
     - RELHUM
     - SHFLX
-    - SST
     - SWCF
     - T
     - TAUX
@@ -498,36 +137,3 @@ diag_var_list:
     - ICEFRAC
     - OCNFRAC
     - LANDFRAC
-    - O3
-    # 2d fields
-    # - SFSO2     0       => 1.4e-10 kg/m2/s (SO2 surface flux)
-    # - WD_DMS   -4.5e-15 => 1.7e-22 kg/m2/s (vertical integrated wet deposition flux)
-    # - WD_SO2   -1.5e-10 => 3.8e-16 kg/m2/s (vertical integrated wet deposition flux)
-    # - DF_DMS   -4.5e-21 => 5.1e-13 kg/m2/s (vertical integrated dry deposition flux)
-    # - DF_H2O2   6.6e-26 => 2.7e-11 kg/m2/s (vertical integrated dry deposition flux)
-   # - DF_SO2    1.5e-27 => 7.0e-10 kg/m2/s (vertical integrated dry deposition flux)
-   # 3d fields
-   # - sum_BC    1.8e-14 => 1.2e-8 kg/kg (sum of BC concentrations)
-   # - sum_DST   6.3e-20 => 7.9e-6 kg/kg
-   # - sum_OM    6.3e-15 => 7.2e-8 kt/kg
-
-#<Add more variables here.>
-
-# Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
-#tem_info:
-    #Location where TEM files are stored:
-    #If path not specified or commented out, TEM calculation/plots will be skipped
-    #tem_loc: /glade/scratch/richling/adf-output/ADF-data/TEM/
-
-    #TEM history file number
-    #If missing or blank, ADF will default to h4
-    #hist_num: h4
-
-    #Overwrite TEM files, if found?
-    #If set to false, then TEM creation will be skipped if files are found:
-    #overwrite_tem_case: false
-
-    #overwrite_tem_case:
-    #overwrite_tem_base: false
-
-#END OF FILE

--- a/config_noresm_default.yaml
+++ b/config_noresm_default.yaml
@@ -70,12 +70,26 @@ regridding_scripts:
 
 analysis_scripts:
     - amwg_table
+   #- ENSO_acrossRuns
+   #- aerosol_gas_tables
 
 plotting_scripts:
     - global_mean_timeseries
     - global_latlon_map
     - zonal_mean
     - meridional_mean
+  # - global_latlon_vect_map
+  # - zonal_mean
+  # - meridional_mean
+  # - polar_map
+  # - cam_taylor_diagram
+  # - qbo
+  # - ozone_diagnostics
+  # - enso_comparison_plots
+  # - tape_recorder
+  # - tem
+  # - regional_map_multicase #To use this please un-comment and fill-out
+                             #the "region_multicase" section below
 
 diag_var_list:
     - AODVIS
@@ -137,3 +151,19 @@ diag_var_list:
     - ICEFRAC
     - OCNFRAC
     - LANDFRAC
+
+# <Add more variables here.>
+
+# Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# for region_time_option - if calendar, will look for specified years, if zeroanchor
+#  will use a nyears starting from year_offset from the beginning of timeseries
+# region_multicase:
+#     region_spec: [slat, nlat, wlon, elon]
+#     region_time_option: <calendar | zeroanchor>
+#     region_start_year:
+#     region_end_year:
+#     region_nyear:
+#     region_year_offset:
+#     region_month: <NULL means look for season>
+#     region_season: <NULL means use annual mean>
+#     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>

--- a/config_noresm_template.yaml
+++ b/config_noresm_template.yaml
@@ -1,9 +1,10 @@
-user: 'mvertens'
-case: 'n1850.ne16pg3_tn14.noresm3_0_beta21.476.2026-07-03'
-nick: 'noresm3_ne30_beta21-run476'
-case_base: 'n1850.ne16pg3_tn14.noresm3_0_beta21.i478.2026-07-06'
-nick_base: 'noresm3_ne30_beta21-run478'
+user: '<user name>'
+case: '<case name>'
+nick: '<case nickname>'
+case_base: 'baseline case name>'
+nick_base: 'baseline case nickname>'
 
+# baseic diagnostic info
 diag_basic_info:
     hist_str: cam.h0a
     compare_obs: false
@@ -20,6 +21,7 @@ diag_basic_info:
     num_procs: 8
     redo_plot: true
 
+# info for target diagnostic case
 diag_cam_climo:
     hist_str: cam.h0a
     calc_cam_climo: true
@@ -38,6 +40,7 @@ diag_cam_climo:
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/tem/
     overwrite_tem: false
 
+# info for baseline compare if not comparing to observations
 diag_cam_baseline_climo:
     hist_str: cam.h0a
     calc_cam_climo: true
@@ -56,23 +59,29 @@ diag_cam_baseline_climo:
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/tem/
     overwrite_tem: false
 
+# don't run cvdp
 diag_cvdp_info:
     cvdp_run: false
 
+# don't run mdtf
 diag_mdtf_info:
     mdtf_run: false
 
+# any of the scripts in scripts/averaging without the .py extension
 time_averaging_scripts:
     - create_climo_files
 
+# any of the scripts in scripts/regridding without the .py extension
 regridding_scripts:
     - regrid_and_vert_interp
 
+# any of the scripts in scripts/analysis without the .py extension
 analysis_scripts:
     - amwg_table
    #- ENSO_acrossRuns
    #- aerosol_gas_tables
 
+# any of the scripts in scripts/plotting without the .py extension
 plotting_scripts:
     - global_mean_timeseries
     - global_latlon_map
@@ -91,6 +100,7 @@ plotting_scripts:
   # - regional_map_multicase #To use this please un-comment and fill-out
                              #the "region_multicase" section below
 
+# variables to diagnose and plot
 diag_var_list:
     - AODVIS
     - cb_SULFATE

--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -16,5 +16,5 @@ dependencies:
   - geocat-comp=2024.04.0
   - python=3.12
   - xesmf>=0.8.8
-prefix: /diagnostics/conda-envs/adf_v1.0.0
+
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -343,6 +343,36 @@ class AdfDiag(AdfWeb):
 
         # End def
 
+        global _regrid_ts_file
+
+        def _regrid_ts_file(args):
+            """Internal worker for the multiprocessing Pool: regrid one native
+            spectral-element (ncol) time-series file to a regular lat/lon grid,
+            overwriting it in place.  Declared global (like call_ncrcat) so the
+            Pool can pickle it.  Idempotent: files that are not on the ncol grid
+            (already lat/lon, or non-SE) are skipped.  Opened time-chunked via
+            dask so long transient time series need not fit in memory at once.
+            """
+            ts_file, weight_file = args
+            import os as _os
+            import xarray as _xr
+            from adf_se_regrid import make_se_regridder, regrid_cam_se_data
+            if not _os.path.isfile(ts_file):
+                return
+            _ds = _xr.open_dataset(ts_file, decode_times=False, chunks={"time": 12})
+            if "ncol" not in _ds.dims:
+                _ds.close()
+                return  # already lat/lon (or not SE) -- nothing to do
+            _regridder = make_se_regridder(weight_file=weight_file)
+            _ds_out = regrid_cam_se_data(_regridder, _ds)
+            _tmp = ts_file + ".regrid.tmp"
+            _unlim = ["time"] if "time" in _ds_out.dims else None
+            _ds_out.to_netcdf(_tmp, unlimited_dims=_unlim)
+            _ds.close()
+            _os.replace(_tmp, ts_file)
+
+        # End def
+
 
         # Check if baseline time-series files are being created:
         if baseline:
@@ -523,6 +553,7 @@ class AdfDiag(AdfWeb):
                 list_of_ncattend_commands = []
                 list_of_hist_commands = []
                 vars_to_derive = []
+                ts_output_files = []  # native SE time-series files to regrid to lat/lon
                 # create copy of var list that can be modified for derivable variables
                 diag_var_list = self.diag_var_list
 
@@ -555,6 +586,9 @@ class AdfDiag(AdfWeb):
                         + os.sep
                         + ".".join([case_name, hist_str, var, time_string, "nc"])
                     )
+
+                    # Track the output file so it can be regridded (SE -> lat/lon) later:
+                    ts_output_files.append(ts_outfil_str)
 
                     # Check if clobber is true for file
                     if Path(ts_outfil_str).is_file():
@@ -765,6 +799,23 @@ class AdfDiag(AdfWeb):
                         res=res, hist_str=hist_str, vars_to_derive=vars_to_derive,
                         constit_dict=constit_dict, ts_dir=ts_dir
                     )
+
+                # Regrid native spectral-element (ncol) time series to lat/lon,
+                # in parallel, if a SE grid is configured.  This overwrites each
+                # time-series file in place, so everything downstream (climo and
+                # all diagnostics) then reads lat/lon time series.  Non-SE
+                # (already lat/lon) files are skipped by the worker.
+                se_grid = self.get_basic_info("cam_se_grid")
+                if se_grid:
+                    weight_file = self.get_basic_info(
+                        f"cam_se_weight_file_{se_grid}", required=True
+                    )
+                    print(f"\n\t Regridding SE (ncol) time series to lat/lon "
+                          f"using '{se_grid}' weights")
+                    regrid_args = [(f, weight_file) for f in ts_output_files]
+                    with mp.Pool(processes=self.num_procs) as mpool:
+                        _ = mpool.map(_regrid_ts_file, regrid_args)
+                # End if
                 # End with
             # End for hist_str
         # End cases loop

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -343,37 +343,6 @@ class AdfDiag(AdfWeb):
 
         # End def
 
-        global _regrid_ts_file
-
-        def _regrid_ts_file(args):
-            """Internal worker for the multiprocessing Pool: regrid one native
-            spectral-element (ncol) time-series file to a regular lat/lon grid,
-            overwriting it in place.  Declared global (like call_ncrcat) so the
-            Pool can pickle it.  Idempotent: files that are not on the ncol grid
-            (already lat/lon, or non-SE) are skipped.  Opened time-chunked via
-            dask so long transient time series need not fit in memory at once.
-            """
-            ts_file, weight_file = args
-            import os as _os
-            import xarray as _xr
-            from adf_se_regrid import make_se_regridder, regrid_cam_se_data
-            if not _os.path.isfile(ts_file):
-                return
-            _ds = _xr.open_dataset(ts_file, decode_times=False, chunks={"time": 12})
-            if "ncol" not in _ds.dims:
-                _ds.close()
-                return  # already lat/lon (or not SE) -- nothing to do
-            _regridder = make_se_regridder(weight_file=weight_file)
-            _ds_out = regrid_cam_se_data(_regridder, _ds)
-            _tmp = ts_file + ".regrid.tmp"
-            _unlim = ["time"] if "time" in _ds_out.dims else None
-            _ds_out.to_netcdf(_tmp, unlimited_dims=_unlim)
-            _ds.close()
-            _os.replace(_tmp, ts_file)
-
-        # End def
-
-
         # Check if baseline time-series files are being created:
         if baseline:
             # Use baseline settings, while converting them all

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -812,9 +812,33 @@ class AdfDiag(AdfWeb):
                     )
                     print(f"\n\t Regridding SE (ncol) time series to lat/lon "
                           f"using '{se_grid}' weights")
-                    regrid_args = [(f, weight_file) for f in ts_output_files]
-                    with mp.Pool(processes=self.num_procs) as mpool:
-                        _ = mpool.map(_regrid_ts_file, regrid_args)
+                    # NOTE: run SERIALLY, not under mp.Pool.  xESMF/ESMF is not
+                    # fork-safe: building/using a regridder inside a forked
+                    # multiprocessing worker deadlocks (the pool hangs with no
+                    # error).  Build the regridder once and reuse it for every
+                    # file -- the regrid is cheap (applying precomputed weights),
+                    # so a serial loop is fast enough here.
+                    import xarray as xr
+                    from adf_se_regrid import make_se_regridder, regrid_cam_se_data
+                    regridder = None
+                    for ts_file in ts_output_files:
+                        if not os.path.isfile(ts_file):
+                            continue
+                        ds_in = xr.open_dataset(
+                            ts_file, decode_times=False, chunks={"time": 12}
+                        )
+                        if "ncol" not in ds_in.dims:
+                            ds_in.close()
+                            continue  # already lat/lon (or not SE) -- skip
+                        if regridder is None:
+                            regridder = make_se_regridder(weight_file=weight_file)
+                        ds_out = regrid_cam_se_data(regridder, ds_in)
+                        tmp = ts_file + ".regrid.tmp"
+                        unlim = ["time"] if "time" in ds_out.dims else None
+                        ds_out.to_netcdf(tmp, unlimited_dims=unlim)
+                        ds_in.close()
+                        os.replace(tmp, ts_file)
+                        print(f"\t    regridded {os.path.basename(ts_file)}")
                 # End if
                 # End with
             # End for hist_str

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -818,7 +818,8 @@ class AdfDiag(AdfWeb):
                     # error).  Build the regridder once and reuse it for every
                     # file -- the regrid is cheap (applying precomputed weights),
                     # so a serial loop is fast enough here.
-                    import xarray as xr
+                    # (xr is imported at module scope; do NOT re-import it here
+                    #  or it becomes function-local and shadows the global.)
                     from adf_se_regrid import make_se_regridder, regrid_cam_se_data
                     regridder = None
                     for ts_file in ts_output_files:

--- a/lib/adf_se_regrid.py
+++ b/lib/adf_se_regrid.py
@@ -1,0 +1,122 @@
+"""Spectral-element (SE) -> lat/lon regridding for the atmosphere (CAM) realm.
+
+Provides an xESMF-based regridder built from a pre-generated ESMF
+weight file, and a routine that regrids all `ncol`-carrying variables
+of a CAM dataset to a regular lat/lon grid while preserving the
+non-horizontal pass-through variables (hyam/hybm/hyai/hybi/P0,
+lev/ilev, time_bnds, gw, ...) and attributes that xESMF otherwise
+drops.
+
+"""
+
+import numpy as np
+import xarray as xr
+import xesmf
+
+
+def _restore_passthrough_and_attrs(ds_out, ds_in, horiz_dim):
+    """Restore variables, coords and attrs that xESMF drops during regridding.
+
+    xESMF only emits variables that carry the horizontal regridding dims;
+    everything else (time_bnds, hyam/hybm/hyai/hybi, P0, lev/ilev, gw, scalar
+    reference values, ...) is dropped, and in older xESMF versions the
+    per-variable and global attrs are lost too.  Copy them back from ds_in.
+    """
+    # Restore global (dataset-level) attrs
+    ds_out.attrs = dict(ds_in.attrs)
+
+    # Restore per-variable attrs/encoding on regridded variables
+    for name in ds_out.variables:
+        if name in ds_in.variables:
+            if not ds_out[name].attrs:
+                ds_out[name].attrs = dict(ds_in[name].attrs)
+            if not ds_out[name].encoding:
+                ds_out[name].encoding = dict(ds_in[name].encoding)
+
+    # Add back any pass-through variables that don't carry the horiz dim
+    for name in ds_in.variables:
+        if name in ds_out.variables:
+            continue
+        if horiz_dim in ds_in[name].dims:
+            # had the horiz dim but didn't survive regridding -- skip
+            continue
+        ds_out[name] = ds_in[name]
+
+    return ds_out
+
+
+def make_se_regridder(weight_file, regrid_method="conserved"):
+    """Build an xESMF Regridder from a pre-generated ESMF weight (map) file.
+
+    Realm-agnostic: the weight file encodes the SE-grid -> lat/lon mapping
+    (e.g. map_ne30pg3_to_0.5x0.5_...nc).
+    """
+    weights = xr.open_dataset(weight_file)
+    in_shape = weights.src_grid_dims.load().data
+
+    # xESMF expects 2D vars, so insert a dummy size-1 dimension
+    if len(in_shape) == 1:
+        in_shape = [1, in_shape.item()]
+
+    out_shape = weights.dst_grid_dims.load().data.tolist()[::-1]
+
+    # bounds (needed for conservative regridding, not for bilinear)
+    lat_b_out = np.zeros(out_shape[0] + 1)
+    lon_b_out = weights.xv_b.data[: out_shape[1] + 1, 0]
+    lat_b_out[:-1] = weights.yv_b.data[np.arange(out_shape[0]) * out_shape[1], 0]
+    lat_b_out[-1] = weights.yv_b.data[-1, -1]
+
+    dummy_in = xr.Dataset(
+        {
+            "lat": ("lat", np.empty((in_shape[0],))),
+            "lon": ("lon", np.empty((in_shape[1],))),
+            "lat_b": ("lat_b", np.empty((in_shape[0] + 1,))),
+            "lon_b": ("lon_b", np.empty((in_shape[1] + 1,))),
+        }
+    )
+    dummy_out = xr.Dataset(
+        {
+            "lat": ("lat", weights.yc_b.data.reshape(out_shape)[:, 0]),
+            "lon": ("lon", weights.xc_b.data.reshape(out_shape)[0, :]),
+            "lat_b": ("lat_b", lat_b_out),
+            "lon_b": ("lon_b", lon_b_out),
+        }
+    )
+
+    regridder = xesmf.Regridder(
+        dummy_in,
+        dummy_out,
+        weights=weight_file,
+        method=regrid_method,
+        reuse_weights=True,
+        periodic=True,
+    )
+    return regridder
+
+
+def regrid_cam_se_data(regridder, ds_in, debug=False):
+    """Regrid all `ncol`-carrying variables of a CAM dataset to lat/lon."""
+    if regridder is None:
+        print("No data to regrid, returning")
+        return ds_in
+
+    dimname = "ncol"
+    ds_in_copy = ds_in.copy()
+
+    # variables that carry the SE horizontal dim
+    vars_to_regrid = [name for name in ds_in.data_vars if dimname in ds_in[name].dims]
+
+    # keep_attrs so units etc. survive the reshape + regrid
+    with xr.set_options(keep_attrs=True):
+        for var in vars_to_regrid:
+            if debug:
+                print(f"var is {var}")
+            ds_in_copy[var] = (
+                ds_in_copy[var].transpose(..., dimname).expand_dims("dummy", axis=-2)
+            )
+
+        ds_out = regridder(ds_in_copy.rename({"dummy": "lat", dimname: "lon"}))
+
+    # restore pass-through vars (hyam/hybm/..., time_bnds, gw, ...) + attrs
+    ds_out = _restore_passthrough_and_attrs(ds_out, ds_in, horiz_dim=dimname)
+    return ds_out

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -234,13 +234,8 @@ AODVISdn:
   pct_diff_colormap: "PuOr_r"
 
 cb_BC:
-  colormap: "Oranges"
   contour_levels_range: [0, 5.5, .5 ]
-  diff_colormap: "PuOr_r"
   diff_contour_range: [-1, 1.1, 0.1]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
   category: "Aerosols"
   colormap: "plasma_r"
   scale_factor: 1000000
@@ -256,22 +251,16 @@ cb_BC:
   obs_add_offset: 0
 
 cb_SULFATE:
-  colormap: "Oranges"
-  contour_levels_range: [0, 11, 1 ]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-2.25, 2.5, 0.25]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
   colormap: "plasma_r"
+  contour_levels_range: [0, 11, 1 ]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-1000, 1100, 100]
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
+  category: "Aerosols"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
-  diff_contour_range: [-1000, 1100, 100]
-  diff_colormap: "RdBu_r"
   obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENDUST"
   obs_name: "CAMS"
@@ -279,38 +268,26 @@ cb_SULFATE:
   obs_add_offset: 0
 
 cb_isoprene:
-  colormap: "Oranges"
-  contour_levels_range: [0, 105, 5 ]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-50, 52.5, 2.5]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
   category: "Aerosols"
   colormap: "plasma_r"
+  contour_levels_range: [0, 105, 5 ]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-50, 52.5, 2.5]
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
-
 
 cb_monoterp:
-  colormap: "Oranges"
-  contour_levels_range: [0, 55, 5 ]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-20, 22.5, 2.5]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
   category: "Aerosols"
   colormap: "plasma_r"
+  contour_levels_range: [0, 55, 5 ]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-200, 200, 25]
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
-  diff_contour_range: [-200, 200, 25]
-  diff_colormap: "RdBu_r"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
   obs_file: "BURDENSEASALT_CAMS_monthly_climo_1degree_200301-202412.nc"
@@ -320,21 +297,16 @@ cb_monoterp:
   obs_add_offset: 0
 
 cb_DMS:
-  colormap: "Oranges"
-  contour_levels_range: [0, 2.25, .25 ]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-0.1, 0.11, 0.01]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
   category: "Aerosols"
   colormap: "plasma_r"
+  contour_levels_range: [0, 2.25, .25 ]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-0.1, 0.11, 0.01]
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
   obs_file: "BURDENSO4_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_name: "CAMS"
   obs_var_name: "BURDENSO4"
@@ -342,6 +314,7 @@ cb_DMS:
   obs_add_offset: 0
 
 cb_DUST:
+  category: "Aerosols"
   colormap: "Oranges"
   contour_levels: [1, 10, 20, 30, 40, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 999, 1000]
   diff_colormap: "PuOr_r"
@@ -350,9 +323,9 @@ cb_DUST:
   scale_factor: 1000000
   add_offset: 0
   new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
 
 cb_OM:
+  category: "Aerosols"
   colormap: "Oranges"
   contour_levels_range: [0, 105, 5 ]
   diff_colormap: "PuOr_r"
@@ -360,9 +333,9 @@ cb_OM:
   scale_factor: 1000000
   add_offset: 0
   new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
 
 cb_H2O2:
+  category: "Aerosols"
   colormap: "Oranges"
   contour_levels_range: [0, 11, 1 ]
   diff_colormap: "PuOr_r"
@@ -370,9 +343,9 @@ cb_H2O2:
   scale_factor: 1000000
   add_offset: 0
   new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
 
 cb_H2SO4:
+  category: "Aerosols"
   colormap: "Oranges"
   contour_levels_range: [0, 1.1, .1 ]
   diff_colormap: "PuOr_r"
@@ -380,9 +353,9 @@ cb_H2SO4:
   scale_factor: 1000000
   add_offset: 0
   new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
 
 cb_SALT:
+  category: "Aerosols"
   colormap: "Oranges"
   contour_levels_range: [0, 105, 5 ]
   diff_colormap: "PuOr_r"
@@ -390,24 +363,18 @@ cb_SALT:
   scale_factor: 1000000
   add_offset: 0
   new_unit: "1e-6 kg/m2"
-  category: "Aerosols"
 
 cb_SO2:
-  colormap: "Oranges"
-  contour_levels_range: [0, 22, 2 ]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-5, 6, 1]
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: "1e-6 kg/m2"
   category: "Aerosols"
   colormap: "plasma_r"
+  contour_levels_range: [0, 22, 2 ]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-5, 6, 1]
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
 
 DMS:
   category: "Aerosols"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -234,9 +234,9 @@ AODVISdn:
   pct_diff_colormap: "PuOr_r"
 
 cb_BC:
+  category: "Aerosols"
   contour_levels_range: [0, 5.5, .5 ]
   diff_contour_range: [-1, 1.1, 0.1]
-  category: "Aerosols"
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
@@ -251,6 +251,7 @@ cb_BC:
   obs_add_offset: 0
 
 cb_SULFATE:
+  category: "Aerosols"
   colormap: "plasma_r"
   contour_levels_range: [0, 11, 1 ]
   diff_colormap: "RdBu_r"
@@ -258,7 +259,6 @@ cb_SULFATE:
   scale_factor: 1000000
   add_offset: 0
   new_unit: 'g m$^{-2}$'
-  category: "Aerosols"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
   obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
@@ -404,6 +404,7 @@ SOAG:
   new_unit: "ppbv"
 
 BC:
+  category: "Aerosols"
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
@@ -412,12 +413,12 @@ BC:
   mpl:
     colorbar:
       label : '$\mu$g/m3'
-  category: "Aerosols"
   derivable_from: ["bc_a1", "bc_a4"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 POM:
+  category: "Aerosols"
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
@@ -426,12 +427,12 @@ POM:
   mpl:
     colorbar:
       label : '$\mu$g/m3'
-  category: "Aerosols"
   derivable_from: ["pom_a1", "pom_a4"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 SO4:
+  category: "Aerosols"
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
@@ -440,13 +441,13 @@ SO4:
   mpl:
     colorbar:
       label : '$\mu$g/m3'
-  category: "Aerosols"
   derivable_from: ["so4_a1", "so4_a2", "so4_a3"]
   derivable_from_cam_chem: ["so4_a1", "so4_a2", "so4_a3", "so4_a5"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 SOA:
+  category: "Aerosols"
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
@@ -455,13 +456,13 @@ SOA:
   mpl:
     colorbar:
       label : '$\mu$g/m3'
-  category: "Aerosols"
   derivable_from: ["soa_a1", "soa_a2"]
   derivable_from_cam_chem: ["soa1_a1", "soa2_a1", "soa3_a1", "soa4_a1", "soa5_a1", "soa1_a2", "soa2_a2", "soa3_a2", "soa4_a2", "soa5_a2"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 DUST:
+  category: "Aerosols"
   colormap: "RdBu_r"
   contour_levels: [0,0.1,0.25,0.4,0.6,0.8,1.4,2,3,4,8,12,30,48,114,180]
   non_linear: True
@@ -472,12 +473,12 @@ DUST:
   mpl:
     colorbar:
       label : '$\mu$g/m3'
-  category: "Aerosols"
   derivable_from: ["dst_a1", "dst_a2", "dst_a3"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 SeaSalt:
+  category: "Aerosols"
   colormap: "RdBu_r"
   contour_levels: [0,0.05,0.075,0.2,0.3,0.4,0.7,1,1.5,2,4,6,15,24,57,90]
   non_linear: True
@@ -492,7 +493,6 @@ SeaSalt:
     diff_colorbar:
       label : '$\mu$g/m3'
       ticks: [-10,8,6,4,2,0,-2,-4,-6,-8,-10]
-  category: "Aerosols"
   derivable_from: ["ncl_a1", "ncl_a2", "ncl_a3"]
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"


### PR DESCRIPTION
Summary

Adds native spectral-element (ncol) → regular lat/lon regridding directly inside ADF (via xESMF), so NorESM CAM-SE output can be diagnosed without a separate pre-regridding step. Also overhauls the configuration files — paring the verbose YAMLs down to values and moving all documentation into a new CONFIG_REFERENCE.md.

Regridding: 

- New lib/adf_se_regrid.py — builds an xESMF regridder from an ESMF weight/map file and regrids all ncol-carrying variables to lat/lon while preserving pass-through fields (hyam/hybm, lev/ilev, time_bnds, gw, …).
  - Regridding is opt-in: with cam_se_grid unset, ADF behaves exactly as before (already-lat/lon input is untouched).
  - Target resolution is defined by the weight file (ne16→1.9×2.5, ne30→0.5×0.5), not a config setting.
- lib/adf_diag.py — hooks regridding into create_time_series: each time-series file is written on the native ncol grid and then overwritten in place as lat/lon, so every downstream step reads lat/lon. Gated by new cam_se_grid / cam_se_weight_file_* config keys; a missing/lat-lon file is skipped.
  - Runs serially, not under mp.Pool — xESMF/ESMF is not fork-safe (a forked worker deadlocks). Regridder built once and reused.

Config & documentation overhaul:

- New CONFIG_REFERENCE.md  — new full, scannable reference 
- Pared-down YAMLs — yaml file templates not are reduced to just values without all the extra verbosity. All of that is now contained in the new CONFIG_REFERENCE.md.
- README.md — adds NIRD setup directions and a pointer to CONFIG_REFERENCE.md.

Testing:

- Validated on ne16: in-core output matches offline pre-regridding (time series, tables, and plots); 3-D fields and the derived cb_* aerosol variables verified. ne30 not yet re-tested.

