### PR TITLE
Add new observation formulas

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import xarray as xr
 
 import adf_utils as utils
+from adf_formula import safe_eval
 warnings.formatwarning = utils.my_formatwarning
 
 # "reference data"
@@ -267,7 +268,12 @@ class AdfData:
         """Return DataArray from reference (aka baseline) climo file"""
         add_offset, scale_factor = self.get_value_converters(case, variablename)
         fils = self.get_reference_climo_file(variablename)
-        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
+        # For obs, the field may be stored under a different name (obs_var_name);
+        # pass it for the direct read while keeping the ADF name for the lookups.
+        obs_name = self.ref_var_nam.get(variablename) if self.adf.compare_obs else None
+        return self.load_da(fils, variablename, derive_obs=self.adf.compare_obs,
+                            obs_var_name=obs_name,
+                            add_offset=add_offset, scale_factor=scale_factor)
 
     def get_reference_climo_file(self, var):
         """Return a list of files to be used as reference (aka baseline) for variable var."""
@@ -353,11 +359,13 @@ class AdfData:
             warnings.warn("\t    WARNING: Did not find regridded file(s) for case: "
                           f"{case}, variable: {field}")
             return None
-        #Change the variable name from CAM standard to what is
-        # listed in variable defaults for this observation field
-        if self.adf.compare_obs:
-            field = self.ref_var_nam[field]
-        return self.load_da(fils, field, add_offset=add_offset, scale_factor=scale_factor)
+        # For obs, the field may be stored under a different name (obs_var_name);
+        # pass it for the direct read while keeping the ADF name (field) for the
+        # derivation and units lookups.
+        obs_name = self.ref_var_nam.get(field) if self.adf.compare_obs else None
+        return self.load_da(fils, field, derive_obs=self.adf.compare_obs,
+                            obs_var_name=obs_name,
+                            add_offset=add_offset, scale_factor=scale_factor)
 
     #------------------
 
@@ -383,17 +391,90 @@ class AdfData:
             warnings.warn("\t    WARNING: invalid data on load_dataset")
         return ds
 
+    def derive_obs_from_formula(self, ds, variablename):
+        """Compute an observational `variablename` from an obs-specific formula.
+
+        This is the single, consistent mechanism for transforming observational
+        data into a model-comparable field.  It covers both:
+          * derivation from constituents - e.g. PRECT = PRECC + PRECL, and
+          * unit conversion / scaling    - e.g. BURDENSO4 = BURDENSO4 * 1e6
+            (a "self-reference" formula), replacing obs_scale_factor/obs_add_offset.
+        Arbitrary combinations are allowed, e.g. "(PRECC + PRECL) * 86400 * 1000".
+
+        It uses observation-specific variable-defaults attributes, deliberately
+        independent of the model attributes because obs names/formula may differ:
+            derivable_from_obs      - input variable names as they appear in the obs file
+            derivation_formula_obs  - formula written in terms of those obs names
+
+        `variablename` is the ADF variable name (the variable_defaults key), so the
+        lookup is independent of obs_var_name (which only names the stored obs field).
+
+        Returns a DataArray (named `variablename`) or None if no usable obs formula
+        is provided or its inputs are not all present in the file.
+        """
+        vres = self.adf.variable_defaults.get(variablename, {})
+        constits = vres.get("derivable_from_obs")
+        formula  = vres.get("derivation_formula_obs")
+        if not constits or not formula:
+            return None
+        if not all(c in ds.data_vars for c in constits):
+            return None
+        da = safe_eval(formula, {c: ds[c] for c in constits})
+        da.name = variablename
+        return da
+
     # Load DataArray
-    def load_da(self, fils, variablename, **kwargs):
-        """Return xarray DataArray from file(s) w/ optional scale factor, offset, new units."""
+    def load_da(self, fils, variablename, derive_obs=False, obs_var_name=None, **kwargs):
+        """Return xarray DataArray from file(s) w/ optional scale factor, offset, new units.
+
+        `variablename` is the ADF variable name (the variable_defaults key) and is used
+        for the derivation and units lookups.  `obs_var_name`, if given, is the name the
+        variable is stored under in the obs file and is used only for the direct read
+        (observations may store a field under a different name than ADF uses).
+
+        When derive_obs is True and a derivation_formula_obs is provided for the
+        variable, that formula fully defines the transform from the obs file (any
+        combination of derivation from constituents and unit conversion), so it is
+        applied and the obs_scale_factor/obs_add_offset step is skipped.  If no
+        obs formula is provided, behavior is unchanged: read the variable directly
+        and apply scale_factor/add_offset (the obs_* values for observations).
+        """
         ds = self.load_dataset(fils)
         if ds is None:
             warnings.warn(f"\t    WARNING: Load failed for {variablename}")
             return None
-        da = ds[variablename].squeeze()
-        scale_factor = kwargs.get('scale_factor', 1)
-        add_offset = kwargs.get('add_offset', 0)
-        da = da * scale_factor + add_offset
+
+        # Name of the field as stored in the file (obs may rename it); the ADF name
+        # (variablename) is always used for the derivation and defaults/units lookups.
+        read_name = obs_var_name if obs_var_name else variablename
+
+        # Observations: prefer a derivation_formula_obs when present - it fully
+        # defines the transform (derivation and/or scaling), so scale/offset is skipped.
+        da = None
+        applied_obs_formula = False
+        if derive_obs:
+            da = self.derive_obs_from_formula(ds, variablename)
+            if da is not None:
+                da = da.squeeze()
+                applied_obs_formula = True
+
+        if da is None:
+            if read_name in ds.data_vars:
+                da = ds[read_name].squeeze()
+            elif derive_obs:
+                warnings.warn(f"\t    WARNING: obs variable {variablename} (file name "
+                              f"'{read_name}') not found and no usable derivation_formula_obs "
+                              "was provided.")
+                return None
+            else:
+                # Preserve prior behavior (raises if the variable is genuinely missing).
+                da = ds[read_name].squeeze()
+
+        # Apply scale/offset only when an obs formula did not already define the transform.
+        if not applied_obs_formula:
+            scale_factor = kwargs.get('scale_factor', 1)
+            add_offset = kwargs.get('add_offset', 0)
+            da = da * scale_factor + add_offset
         if variablename in self.adf.variable_defaults:
             vres = self.adf.variable_defaults[variablename]
             da.attrs['units'] = vres.get("new_unit", da.attrs.get('units', 'none'))

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -403,8 +403,8 @@ class AdfData:
 
         It uses observation-specific variable-defaults attributes, deliberately
         independent of the model attributes because obs names/formula may differ:
-            derivable_from_obs      - input variable names as they appear in the obs file
-            derivation_formula_obs  - formula written in terms of those obs names
+            obs_derivable_from      - input variable names as they appear in the obs file
+            obs_derivation_formula  - formula written in terms of those obs names
 
         `variablename` is the ADF variable name (the variable_defaults key), so the
         lookup is independent of obs_var_name (which only names the stored obs field).
@@ -413,8 +413,8 @@ class AdfData:
         is provided or its inputs are not all present in the file.
         """
         vres = self.adf.variable_defaults.get(variablename, {})
-        constits = vres.get("derivable_from_obs")
-        formula  = vres.get("derivation_formula_obs")
+        constits = vres.get("obs_derivable_from")
+        formula  = vres.get("obs_derivation_formula")
         if not constits or not formula:
             return None
         if not all(c in ds.data_vars for c in constits):
@@ -432,7 +432,7 @@ class AdfData:
         variable is stored under in the obs file and is used only for the direct read
         (observations may store a field under a different name than ADF uses).
 
-        When derive_obs is True and a derivation_formula_obs is provided for the
+        When derive_obs is True and a obs_derivation_formula is provided for the
         variable, that formula fully defines the transform from the obs file (any
         combination of derivation from constituents and unit conversion), so it is
         applied and the obs_scale_factor/obs_add_offset step is skipped.  If no
@@ -448,7 +448,7 @@ class AdfData:
         # (variablename) is always used for the derivation and defaults/units lookups.
         read_name = obs_var_name if obs_var_name else variablename
 
-        # Observations: prefer a derivation_formula_obs when present - it fully
+        # Observations: prefer a obs_derivation_formula when present - it fully
         # defines the transform (derivation and/or scaling), so scale/offset is skipped.
         da = None
         applied_obs_formula = False
@@ -463,7 +463,7 @@ class AdfData:
                 da = ds[read_name].squeeze()
             elif derive_obs:
                 warnings.warn(f"\t    WARNING: obs variable {variablename} (file name "
-                              f"'{read_name}') not found and no usable derivation_formula_obs "
+                              f"'{read_name}') not found and no usable obs_derivation_formula "
                               "was provided.")
                 return None
             else:

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -23,16 +23,23 @@
 #                         Currently only accepts "ocean", which means the variable will be masked
 #                         everywhere that isn't open ocean.
 #
+# derivable_from       -> If not present in the available output files, the variable can be derived from
+#                         other variables that are present (e.g. PRECT can be derived from PRECC and PRECL),
+# derivation_formula   -> If derivable_from is specified then an accompanying derivation_fromula must
+#                         also be specified
 #
 # OBSERVATIONS:
 #
-# obs_file     -> Path to observations file.  If only the file name is given, then the file is assumed to
-#                 exist in the path specified by "obs_data_loc" in the config file.
-# obs_name     -> Name of the observational dataset (mostly used for plotting and generated file naming).
-#                 If this isn't present then the obs_file name is used.
-# obs_var_name -> Variable in the observations file to compare against.  If this isn't present then the
-#                 variable name is assumed to be the same as the model variable name.
-#
+# obs_file		 -> Path to observations file.  If only the file name is given, then the file is assumed to
+#                           exist in the path specified by "obs_data_loc" in the config file.
+# obs_name		 -> Name of the observational dataset (mostly used for plotting and generated file naming).
+#                           If this isn't present then the obs_file name is used.
+# obs_var_name		 -> Variable in the observations file to compare against.  If this isn't present then the
+#                           variable name is assumed to be the same as the model variable name.
+# derivable_from_obs	 -> If not present in the available output files, the variable can be derived from
+#                           other observational variables that are present
+# derivation_formula_obs -> If derivable_from is specified then an accompanying derivation_fromula_obs must
+#                           also be specified
 #
 # VECTORS:
 #
@@ -49,16 +56,6 @@
 #
 #
 # DERIVING:
-#
-# derivable_from -> If not present in the available output files, the variable can be derived from
-#                   other variables that are present (e.g. PRECT can be derived from PRECC and PRECL),
-# derivation_formula -> If derivable_from is specified then an accompanying derivation_fromula must
-#                       also be specified
-#
-# derivable_from_obs -> If not present in the available output files, the variable can be derived from
-#                       other observational variables that are present
-# derivation_formula_obs -> If derivable_from is specified then an accompanying derivation_fromula_obs must
-#                           also be specified
 #
 # Final Note:  Please do not modify this file unless you plan to push your changes back to the ADF repo.
 #              If you would like to modify this file for your personal ADF runs then it is recommended
@@ -1234,13 +1231,11 @@ PRECT:
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
+  derivable_from: ['PRECL','PRECC']
+  derivation_formula: "(PRECC + PRECL) * 86400000"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
   obs_var_name: "PRECT"
-  derivable_from_obs: ['TGCLDWP']
-  derivation_formula_obs: "TGCLDWP * 1000"
-  derivable_from: ['PRECL','PRECC']
-  derivation_formula: "(PRECC + PRECL) * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1402,9 +1402,8 @@ ALBEDOC:
       label : "dimensionless"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF"
-  obs_var_name: "ALBEDOC"
-  obs_derivable_from: ['solar_mon','total_sw_clr_c_mon']
-  obs_derivation_formula: "total_sw_clr_c_mon/solar_mon"
+  derivable_from_obs: ['solar_mon','total_sw_clr_c_mon']
+  derivation_formula_obs: "total_sw_clr_c_mon/solar_mon"
   category: "TOA energy flux"
 
 #+++++++++++++++++

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1372,40 +1372,6 @@ LANDFRAC:
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
-ALBEDO:
-  colormap: "Blues"
-  contour_levels_range: [0, 1, .1]
-  diff_colormap: "BrBG"
-  diff_contour_range: [-0.5, 0.5, .05]
-  new_unit: "dimensionless"
-  derivable_from: ['SOLIN','FSNTOA']
-  derivation_formula: "(SOLIN-FSNTOA)/SOLIN"
-  mpl:
-    colorbar:
-      label : "dimensionless"
-  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
-  obs_name: "CERES-EBAF"
-  obs_derivable_from: ['solar_mon','fsnt']
-  obs_derivation_formula: "(solar_mon-fsnt)/solar_mon"
-  category: "TOA energy flux"
-
-ALBEDOC:
-  colormap: "Blues"
-  contour_levels_range: [0, 1, .05]
-  diff_colormap: "BrBG"
-  diff_contour_range: [-0.3, 0.3, .05]
-  new_unit: "dimensionless"
-  derivable_from: ['SOLIN','FSNTOAC']
-  derivation_formula: "(SOLIN-FSNTOAC)/SOLIN"
-  mpl:
-    colorbar:
-      label : "dimensionless"
-  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
-  obs_name: "CERES_EBAF"
-  derivable_from_obs: ['solar_mon','total_sw_clr_c_mon']
-  derivation_formula_obs: "total_sw_clr_c_mon/solar_mon"
-  category: "TOA energy flux"
-
 #+++++++++++++++++
 # Category: State
 #+++++++++++++++++
@@ -1545,7 +1511,42 @@ QRS:
 # Category: TOA energy flux
 #+++++++++++++++++
 
+ALBEDO:
+  category: "TOA energy flux"
+  colormap: "Blues"
+  contour_levels_range: [0, 1, .1]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.5, 0.5, .05]
+  new_unit: "dimensionless"
+  derivable_from: ['SOLIN','FSNTOA']
+  derivation_formula: "(SOLIN-FSNTOA)/SOLIN"
+  mpl:
+    colorbar:
+      label : "dimensionless"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES-EBAF"
+  obs_derivable_from: ['solar_mon','fsnt']
+  obs_derivation_formula: "(solar_mon-fsnt)/solar_mon"
+
+ALBEDOC:
+  category: "TOA energy flux"
+  colormap: "Blues"
+  contour_levels_range: [0, 1, .05]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.3, 0.3, .05]
+  new_unit: "dimensionless"
+  derivable_from: ['SOLIN','FSNTOAC']
+  derivation_formula: "(SOLIN-FSNTOAC)/SOLIN"
+  mpl:
+    colorbar:
+      label : "dimensionless"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF"
+  obs_derivable_from: ['solar_mon','total_sw_clr_c_mon']
+  obs_derivation_formula: "total_sw_clr_c_mon/solar_mon"
+
 RESTOM:
+  category: "TOA energy flux"
   colormap: "RdBu_r"
   contour_levels_range: [-100, 100, 5]
   diff_colormap: "seismic"
@@ -1554,13 +1555,13 @@ RESTOM:
   mpl:
     colorbar:
       label : "W m$^{-2}$"
-  category: "TOA energy flux"
   derivable_from: ['FLNT','FSNT']
   derivation_formula: "FSNT - FLNT"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 SWCF:
+  category: "TOA energy flux"
   colormap: "Blues"
   contour_levels_range: [-150, 50, 10]
   diff_colormap: "BrBG"
@@ -1572,11 +1573,11 @@ SWCF:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_sw_mon"
-  category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 LWCF:
+  category: "TOA energy flux"
   colormap: "Oranges"
   contour_levels_range: [-10, 100, 5]
   diff_colormap: "BrBG"
@@ -1588,11 +1589,11 @@ LWCF:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_lw_mon"
-  category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 FSUTOA:
+  category: "TOA energy flux"
   colormap: "Blues"
   contour_levels_range: [-10, 180, 15]
   diff_colormap: "BrBG"
@@ -1601,11 +1602,11 @@ FSUTOA:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
-  category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 FSNT:
+  category: "TOA energy flux"
   colormap: "Blues"
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
@@ -1617,7 +1618,6 @@ FSNT:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "fsnt"
-  category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1637,6 +1637,7 @@ FLUT:
   pct_diff_colormap: "PuOr_r"
 
 FLNT:
+  obs_var_name: "toa_lw_all_mon"
   colormap: "Oranges"
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
@@ -1647,12 +1648,12 @@ FLNT:
       label : "Wm$^{-2}$"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "toa_lw_all_mon"
   category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 FLNTC:
+  category: "TOA energy flux"
   colormap: "Oranges"
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
@@ -1664,7 +1665,6 @@ FLNTC:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_lw_clr_t_mon"
-  category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -36,9 +36,9 @@
 #                           If this isn't present then the obs_file name is used.
 # obs_var_name		 -> Variable in the observations file to compare against.  If this isn't present then the
 #                           variable name is assumed to be the same as the model variable name.
-# derivable_from_obs	 -> If not present in the available output files, the variable can be derived from
+# obs_derivable_from	 -> If not present in the available output files, the variable can be derived from
 #                           other observational variables that are present
-# derivation_formula_obs -> If derivable_from is specified then an accompanying derivation_fromula_obs must
+# obs_derivation_formula -> If derivable_from is specified then an accompanying derivation_fromula_obs must
 #                           also be specified
 #
 # VECTORS:
@@ -1116,8 +1116,8 @@ TGCLDLWP:
   category: "Clouds"
   obs_file: "TGCLDLWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
-  derivable_from_obs: ['TGCLDWP']
-  derivation_formula_obs: "TGCLDWP * 1000"
+  obs_derivable_from: ['TGCLDWP']
+  obs_derivation_formula: "TGCLDWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1133,8 +1133,8 @@ TGCLDIWP:
   category: "Clouds"
   obs_file: "TGCLDIWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
-  derivable_from_obs: ['TGCLDIWP']
-  derivation_formula_obs: "TGCLDIWP * 1000"
+  obs_derivable_from: ['TGCLDIWP']
+  obs_derivation_formula: "TGCLDIWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1385,8 +1385,8 @@ ALBEDO:
       label : "dimensionless"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES-EBAF"
-  derivable_from_obs: ['solar_mon','fsnt']
-  derivation_formula_obs: "(solar_mon-fsnt)/solar_mon"
+  obs_derivable_from: ['solar_mon','fsnt']
+  obs_derivation_formula: "(solar_mon-fsnt)/solar_mon"
   category: "TOA energy flux"
 
 ALBEDOC:
@@ -1403,8 +1403,8 @@ ALBEDOC:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF"
   obs_var_name: "ALBEDOC"
-  derivable_from_obs: ['solar_mon','total_sw_clr_c_mon']
-  derivation_formula_obs: "total_sw_clr_c_mon/solar_mon"
+  obs_derivable_from: ['solar_mon','total_sw_clr_c_mon']
+  obs_derivation_formula: "total_sw_clr_c_mon/solar_mon"
   category: "TOA energy flux"
 
 #+++++++++++++++++

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1040,8 +1040,6 @@ CLDTOT:
   contour_levels_range: [0.2, 1.1, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1055,8 +1053,6 @@ CLDLOW:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1070,8 +1066,6 @@ CLDHGH:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1085,8 +1079,6 @@ CLDMED:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1128,8 +1120,8 @@ TGCLDLWP:
   obs_file: "TGCLDLWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "TGCLDLWP"
-  obs_scale_factor: 1000
-  obs_add_offset: 0
+  derivable_from_obs: ['TGCLDWP']
+  derivation_formula_obs: "TGCLDWP * 1e3"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1148,8 +1140,8 @@ TGCLDIWP:
   obs_file: "TGCLDIWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "TGCLDIWP"
-  obs_scale_factor: 1000
-  obs_add_offset: 0
+  derivable_from_obs: ['TGCLDIWP']
+  derivation_formula_obs: "TGCLDIWP * 1e3"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1312,8 +1304,6 @@ TREFHT:
   obs_var_name: "TREFHT"
   contour_levels_range: [220,320, 5]
   diff_contour_range: [-10, 10, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "K"
 
 TS:
@@ -1321,8 +1311,6 @@ TS:
   contour_levels_range: [220,320, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "K"
   mpl:
     colorbar:
@@ -1339,8 +1327,6 @@ SST:
   contour_levels_range: [220,320, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "K"
   mpl:
     colorbar:
@@ -1405,8 +1391,6 @@ TMQ:
   contour_levels_range: [0, 75.0, 5.0]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "kg m$^{-2}$"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1420,8 +1404,6 @@ RELHUM:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Fraction"
   mpl:
     colorbar:
@@ -1438,8 +1420,6 @@ U:
   contour_levels_range: [-10, 90, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "ms$^{-1}$"
   mpl:
     colorbar:
@@ -1458,8 +1438,6 @@ V:
   contour_levels_range: [-10, 90, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "ms$^{-1}$"
   mpl:
     colorbar:
@@ -1549,8 +1527,6 @@ RESTOM:
   contour_levels_range: [-100, 100, 5]
   diff_colormap: "seismic"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "W m$^{-2}$"
   mpl:
     colorbar:
@@ -1566,8 +1542,6 @@ SWCF:
   contour_levels_range: [-150, 50, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1575,8 +1549,6 @@ SWCF:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_sw_mon"
-  obs_scale_factor: 1
-  obs_add_offset: 0
   category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
@@ -1586,8 +1558,6 @@ LWCF:
   contour_levels_range: [-10, 100, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1604,8 +1574,6 @@ FSUTOA:
   contour_levels_range: [-10, 180, 15]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1619,8 +1587,6 @@ FSNT:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1652,8 +1618,6 @@ FLNT:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1670,8 +1634,6 @@ FLNTC:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1702,8 +1664,6 @@ FSNS:
   contour_levels_range: [-10, 300, 20]
   diff_colormap: "BrBG"
   diff_contour_range: [-24, 24, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1720,8 +1680,6 @@ FSNSC:
   contour_levels_range: [-10, 300, 20]
   diff_colormap: "BrBG"
   diff_contour_range: [-24, 24, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1738,8 +1696,6 @@ FLDS:
   contour_levels_range: [100, 500, 25]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1771,8 +1727,6 @@ LHFLX:
   contour_levels_range: [0, 220, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-45, 45, 5]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -1898,8 +1852,6 @@ CLDTOT_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -1911,8 +1863,6 @@ CLDHGH_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -1924,8 +1874,6 @@ CLDMED_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -1937,8 +1885,6 @@ CLDLOW_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -1950,8 +1896,6 @@ CLD_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -1966,8 +1910,6 @@ CLD_CAL:
 H2O:
   colormap: "PuOr_r"
   diff_colormap: "BrBG"
-  scale_factor: 1
-  add_offset: 0
   new_unit: "mol mol$^{-1}$"
   mpl:
     colorbar:

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1542,8 +1542,8 @@ ALBEDOC:
       label : "dimensionless"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF"
-  obs_derivable_from: ['solar_mon','total_sw_clr_c_mon']
-  obs_derivation_formula: "total_sw_clr_c_mon/solar_mon"
+  obs_derivable_from: ['solar_mon','toa_sw_clr_c_mon']
+  obs_derivation_formula: "toa_sw_clr_c_mon/solar_mon"
 
 RESTOM:
   category: "TOA energy flux"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1390,7 +1390,6 @@ ALBEDO:
       label : "dimensionless"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES-EBAF"
-  obs_var_name: "ALBEDO"
   derivable_from_obs: ['solar_mon','fsnt']
   derivation_formula_obs: "(solar_mon-fsnt)/solar_mon"
   category: "TOA energy flux"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1391,7 +1391,7 @@ ALBEDO:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES-EBAF"
   obs_var_name: "ALBEDO"
-  derivable_from_obs:['solar_mon','fsnt']
+  derivable_from_obs: ['solar_mon','fsnt']
   derivation_formula_obs: "(solar_mon-fsnt)/solar_mon"
   category: "TOA energy flux"
 
@@ -1409,7 +1409,7 @@ ALBEDOC:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF"
   obs_var_name: "ALBEDOC"
-  derivable_from_obs:['solar_mon','total_sw_clr_c_mon']
+  derivable_from_obs: ['solar_mon','total_sw_clr_c_mon']
   derivation_formula_obs: "total_sw_clr_c_mon/solar_mon"
   category: "TOA energy flux"
 

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1,4 +1,3 @@
-
 #This file lists out variable-specific defaults
 #for plotting and observations.  These defaults
 #are:
@@ -56,6 +55,10 @@
 # derivation_formula -> If derivable_from is specified then an accompanying derivation_fromula must
 #                       also be specified
 #
+# derivable_from_obs -> If not present in the available output files, the variable can be derived from
+#                       other observational variables that are present
+# derivation_formula_obs -> If derivable_from is specified then an accompanying derivation_fromula_obs must
+#                           also be specified
 #
 # Final Note:  Please do not modify this file unless you plan to push your changes back to the ADF repo.
 #              If you would like to modify this file for your personal ADF runs then it is recommended
@@ -1093,7 +1096,6 @@ CLOUD:
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
   scale_factor: 100
-  add_offset: 0
   new_unit: "Percent"
   mpl:
     colorbar:
@@ -1110,8 +1112,6 @@ TGCLDLWP:
   contour_levels_range: [0, 400, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-100, 100, 10]
-  scale_factor: 1000
-  add_offset: 0
   new_unit: "g m$^{-2}$"
   mpl:
     colorbar:
@@ -1119,9 +1119,8 @@ TGCLDLWP:
   category: "Clouds"
   obs_file: "TGCLDLWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
-  obs_var_name: "TGCLDLWP"
   derivable_from_obs: ['TGCLDWP']
-  derivation_formula_obs: "TGCLDWP * 1e3"
+  derivation_formula_obs: "TGCLDWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1130,8 +1129,6 @@ TGCLDIWP:
   contour_levels_range: [0, 100, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-50, 50, 5]
-  scale_factor: 1000
-  add_offset: 0
   new_unit: "g m$^{-2}$"
   mpl:
     colorbar:
@@ -1139,9 +1136,8 @@ TGCLDIWP:
   category: "Clouds"
   obs_file: "TGCLDIWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
-  obs_var_name: "TGCLDIWP"
   derivable_from_obs: ['TGCLDIWP']
-  derivation_formula_obs: "TGCLDIWP * 1e3"
+  derivation_formula_obs: "TGCLDIWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1169,72 +1165,71 @@ WPTHLP_CLUBB:
 #+++++++++++++++++
 
 PRECC:
+  category: "Hydrologic cycle"
   colormap: "Greens"
   contour_levels_range: [0, 20, 1]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 86400000
-  add_offset: 0
   new_unit: "mm d$^{-1}$"
   mpl:
     colorbar:
       label : "mm/d"
-  category: "Hydrologic cycle"
+  derivable_from: ['PRECC']
+  derivation_formula: "PRECC * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 PRECL:
+  category: "Hydrologic cycle"
   colormap: "Greens"
   contour_levels_range: [0, 20, 1]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 86400000
-  add_offset: 0
   new_unit: "mm d$^{-1}$"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
-  category: "Hydrologic cycle"
+  derivable_from: ['PRECL']
+  derivation_formula: "PRECL * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 PRECSC:
+  category: "Hydrologic cycle"
   colormap: "Greens"
   contour_levels_range: [0, 20, 1]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 86400000
-  add_offset: 0
   new_unit: "mm d$^{-1}$"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
-  category: "Hydrologic cycle"
+  derivable_from: ['PRECSC']
+  derivation_formula: "PRECSC * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 PRECSL:
+  category: "Hydrologic cycle"
   colormap: "Greens"
   contour_levels_range: [0, 20, 1]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 86400000
-  add_offset: 0
   new_unit: "mm d$^{-1}$"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
-  category: "Hydrologic cycle"
+  derivable_from: ['PRECSL']
+  derivation_formula: "PRECSL * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
 PRECT:
+  category: "Hydrologic cycle"
   colormap: "Blues"
   contour_levels_range: [0, 20, 1]
   diff_colormap: "seismic"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 86400000
-  add_offset: 0
   new_unit: "mm d$^{-1}$"
   mpl:
     colorbar:
@@ -1242,9 +1237,10 @@ PRECT:
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
   obs_var_name: "PRECT"
-  category: "Hydrologic cycle"
+  derivable_from_obs: ['TGCLDWP']
+  derivation_formula_obs: "TGCLDWP * 1000"
   derivable_from: ['PRECL','PRECC']
-  derivation_formula: "PRECC + PRECL"
+  derivation_formula: "(PRECC + PRECL) * 86400000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1267,7 +1263,6 @@ PSL:
   diff_colormap: "PuOr_r"
   diff_contour_range: [-9, 9, 0.5]
   scale_factor: 0.01
-  add_offset: 0
   new_unit: "hPa"
   mpl:
     colorbar:
@@ -1285,7 +1280,6 @@ PS:
   diff_colormap: "PuOr_r"
   diff_contour_range: [-9, 9, 0.5]
   scale_factor: 0.01
-  add_offset: 0
   new_unit: "hPa"
   mpl:
     colorbar:
@@ -1354,16 +1348,17 @@ TAUX:
   vector_name: "Surface_Wind_Stress"
   category: "Surface variables"
   scale_factor: -1
-  add_offset: 0
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
+  obs_file: "TAUX_ERA5_monthly_climo_1degree_197901-202212.nc"
+  obs_name: "ERA5"
+  obs_var_name: "TAUX"
 
 TAUY:
   vector_pair: "TAUX"
   vector_name: "Surface_Wind_Stress"
   category: "Surface variables"
   scale_factor: -1
-  add_offset: 0
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1381,6 +1376,42 @@ LANDFRAC:
   category: "Surface variables"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
+
+ALBEDO:
+  colormap: "Blues"
+  contour_levels_range: [0, 1, .1]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.5, 0.5, .05]
+  new_unit: "dimensionless"
+  derivable_from: ['SOLIN','FSNTOA']
+  derivation_formula: "(SOLIN-FSNTOA)/SOLIN"
+  mpl:
+    colorbar:
+      label : "dimensionless"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES-EBAF"
+  obs_var_name: "ALBEDO"
+  derivable_from_obs:['solar_mon','fsnt']
+  derivation_formula_obs: "(solar_mon-fsnt)/solar_mon"
+  category: "TOA energy flux"
+
+ALBEDOC:
+  colormap: "Blues"
+  contour_levels_range: [0, 1, .05]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.3, 0.3, .05]
+  new_unit: "dimensionless"
+  derivable_from: ['SOLIN','FSNTOAC']
+  derivation_formula: "(SOLIN-FSNTOAC)/SOLIN"
+  mpl:
+    colorbar:
+      label : "dimensionless"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF"
+  obs_var_name: "ALBEDOC"
+  derivable_from_obs:['solar_mon','total_sw_clr_c_mon']
+  derivation_formula_obs: "total_sw_clr_c_mon/solar_mon"
+  category: "TOA energy flux"
 
 #+++++++++++++++++
 # Category: State
@@ -1480,7 +1511,6 @@ OMEGA500:
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
   scale_factor: 864
-  add_offset: 0
   new_unit: "hPa d$^{-1}$"
   hist_bins: [-105, -100,  -95,  -90,  -85,  -80,  -75,  -70,  -65,  -60,  -55, -50,  -45,  -40,  -35,  -30,  -25,  -20,  -15,  -10,   -5,    0, 5,   10,   15,   20,   25,   30,   35,   40,   45,   50,   55, 60,   65,   70,   75,   80,   85,   90,   95,  100]
 

--- a/lib/adf_variable_defaults_cesm.yaml
+++ b/lib/adf_variable_defaults_cesm.yaml
@@ -28,8 +28,6 @@ AODDUST:
   contour_levels_range: [0.01, 0.6, 0.05]
   diff_colormap: "PuOr_r"
   diff_contour_range: [-0.06, 0.06, 0.01]
-  scale_factor: 1
-  add_offset: 0
   new_unit: ""
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
@@ -40,8 +38,6 @@ AODVIS:
   contour_levels_range: [0.05, 0.6, 0.05]
   diff_colormap: "PuOr_r"
   diff_contour_range: [-0.1, 0.1, 0.01]
-  scale_factor: 1
-  add_offset: 0
   new_unit: ""
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
@@ -52,8 +48,6 @@ AODVISdn:
   contour_levels_range: [0.01, 1.01, 0.05]
   diff_colormap: "PuOr_r"
   diff_contour_range: [-0.4, 0.401, 0.05]
-  scale_factor: 1
-  add_offset: 0
   new_unit: ""
   obs_file: "MOD08_M3_192x288_AOD_2001-2020_climo.nc"
   obs_name: "MODIS"

--- a/lib/adf_variable_defaults_era5-1deg.yaml
+++ b/lib/adf_variable_defaults_era5-1deg.yaml
@@ -137,441 +137,6 @@ FCTI:
 FICE:
   category: "Microphysics"
 
-#+++++++++++
-# Category: Aerosols
-#+++++++++++
-
-#List of zonal areosols
-aerosol_zonal_list: ["BC","POM","SO4","SOA","NH4HSO4","DUST","SeaSalt"]
-
-AODDUST:
-  category: "Aerosols"
-  colormap: "Oranges"
-  contour_levels_range: [0.01, 0.6, 0.05]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-0.06, 0.06, 0.01]
-  scale_factor: 1
-  add_offset: 0
-  new_unit: ""
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-AODVIS:
-  category: "Aerosols"
-  colormap: "Oranges"
-  contour_levels_range: [0.05, 0.6, 0.05]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-0.1, 0.1, 0.01]
-  scale_factor: 1
-  add_offset: 0
-  new_unit: ""
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-AODVISdn:
-  category: "Aerosols"
-  colormap: "jet"
-  contour_levels_range: [0.01, 1.01, 0.05]
-  diff_colormap: "PuOr_r"
-  diff_contour_range: [-0.4, 0.401, 0.05]
-  scale_factor: 1
-  add_offset: 0
-  new_unit: ""
-  obs_file: "MOD08_M3_192x288_AOD_2001-2020_climo.nc"
-  obs_name: "MODIS"
-  obs_var_name: "AOD_550_Dark_Target_Deep_Blue_Combined_Mean_Mean"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-BURDENBC:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
-  obs_file: "BURDENBC_MERRA2_monthly_climo_1degree_200001-202506.nc"
-  obs_var_name: "BURDENBC"
-  obs_name: "MERRA2"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
-
-BURDENDUST:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  diff_contour_range: [-1000, 1100, 100]
-  diff_colormap: "RdBu_r"
-  obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
-  obs_var_name: "BURDENDUST"
-  obs_name: "CAMS"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
-
-BURDENPOM:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
-
-
-BURDENSEASALT:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  diff_contour_range: [-200, 200, 25]
-  diff_colormap: "RdBu_r"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  obs_file: "BURDENSEASALT_CAMS_monthly_climo_1degree_200301-202412.nc"
-  obs_var_name: "BURDENSEASALT"
-  obs_name: "CAMS"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
-
-BURDENSO4:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
-  obs_file: "BURDENSO4_CAMS_monthly_climo_1degree_200301-202412.nc"
-  obs_name: "CAMS"
-  obs_var_name: "BURDENSO4"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
-
-BURDENSOA:
-  category: "Aerosols"
-  colormap: "plasma_r"
-  scale_factor: 1000000
-  add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  diff_colormap: "RdBu_r"
-
-DMS:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  scale_factor: 1000000000.0
-  new_unit: "ppbv"
-
-SO2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  scale_factor: 1000000000.0
-  new_unit: "ppbv"
-
-SOAG:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  scale_factor: 1000000000.0
-  new_unit: "ppbv"
-
-BC:
-  colormap: "RdBu_r"
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-  category: "Aerosols"
-  derivable_from: ["bc_a1", "bc_a4"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-POM:
-  colormap: "RdBu_r"
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-  category: "Aerosols"
-  derivable_from: ["pom_a1", "pom_a4"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-SO4:
-  colormap: "RdBu_r"
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-  category: "Aerosols"
-  derivable_from: ["so4_a1", "so4_a2", "so4_a3"]
-  derivable_from_cam_chem: ["so4_a1", "so4_a2", "so4_a3", "so4_a5"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-SOA:
-  colormap: "RdBu_r"
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-  category: "Aerosols"
-  derivable_from: ["soa_a1", "soa_a2"]
-  derivable_from_cam_chem: ["soa1_a1", "soa2_a1", "soa3_a1", "soa4_a1", "soa5_a1", "soa1_a2", "soa2_a2", "soa3_a2", "soa4_a2", "soa5_a2"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-DUST:
-  colormap: "RdBu_r"
-  contour_levels: [0,0.1,0.25,0.4,0.6,0.8,1.4,2,3,4,8,12,30,48,114,180]
-  non_linear: True
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-  category: "Aerosols"
-  derivable_from: ["dst_a1", "dst_a2", "dst_a3"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
-SeaSalt:
-  colormap: "RdBu_r"
-  contour_levels: [0,0.05,0.075,0.2,0.3,0.4,0.7,1,1.5,2,4,6,15,24,57,90]
-  non_linear: True
-  diff_colormap: "BrBG"
-  scale_factor: 1000000000
-  add_offset: 0
-  new_unit: '$\mu$g/m3'
-  mpl:
-    colorbar:
-      label : '$\mu$g/m3'
-      ticks: [0.05,0.2,0.4,1,2,6,24,90]
-    diff_colorbar:
-      label : '$\mu$g/m3'
-      ticks: [-10,8,6,4,2,0,-2,-4,-6,-8,-10]
-  category: "Aerosols"
-  derivable_from: ["ncl_a1", "ncl_a2", "ncl_a3"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-  
-bc_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-bc_a4:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-dst_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-dst_a2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-dst_a3:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-ncl_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-ncl_a2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-ncl_a3:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-num_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-num_a2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-num_a3:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-num_a4:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-num_a5:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-pom_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-pom_a4:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-so4_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-so4_a2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-so4_a3:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-soa_a1:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-soa_a2:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0e-9
-  new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-SAD_TROP:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0
-  new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-SAD_AERO:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0
-  new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-SAD_SULFC:
-  category: "Aerosols"
-  colormap: "jet"
-  diff_colormap: "gist_ncar"
-  scale_factor: 1.0
-  new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
-
 #+++++++++++++++++
 # Category: Budget
 #+++++++++++++++++
@@ -1476,8 +1041,6 @@ CLDTOT:
   contour_levels_range: [0.2, 1.1, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1491,8 +1054,6 @@ CLDLOW:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1506,8 +1067,6 @@ CLDHGH:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1521,8 +1080,6 @@ CLDMED:
   contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
   diff_contour_range: [-0.4, 0.4, 0.05]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1751,8 +1308,6 @@ TS:
   contour_levels_range: [220,320, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "K"
   mpl:
     colorbar:
@@ -1769,8 +1324,6 @@ SST:
   contour_levels_range: [220,320, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "K"
   mpl:
     colorbar:
@@ -1841,8 +1394,6 @@ TMQ:
   contour_levels_range: [0, 75.0, 5.0]
   diff_colormap: "BrBG"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "kg m$^{-2}$"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
@@ -1856,8 +1407,6 @@ RELHUM:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Fraction"
   mpl:
     colorbar:
@@ -1874,8 +1423,6 @@ U:
   contour_levels_range: [-10, 90, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "ms$^{-1}$"
   mpl:
     colorbar:
@@ -1894,8 +1441,6 @@ V:
   contour_levels_range: [-10, 90, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "ms$^{-1}$"
   mpl:
     colorbar:
@@ -1985,14 +1530,13 @@ RESTOM:
   contour_levels_range: [-100, 100, 5]
   diff_colormap: "seismic"
   diff_contour_range: [-10, 10, 0.5]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "W m$^{-2}$"
   mpl:
     colorbar:
       label : "W m$^{-2}$"
   category: "TOA energy flux"
   derivable_from: ['FLNT','FSNT']
+  derivation_formula: "FSNT - FLNT"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -2001,8 +1545,6 @@ SWCF:
   contour_levels_range: [-150, 50, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2019,8 +1561,6 @@ LWCF:
   contour_levels_range: [-10, 100, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2037,8 +1577,6 @@ FSUTOA:
   contour_levels_range: [-10, 180, 15]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 1]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2052,8 +1590,6 @@ FSNT:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2085,8 +1621,6 @@ FLNT:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2103,8 +1637,6 @@ FLNTC:
   contour_levels_range: [120, 320, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2135,8 +1667,6 @@ FSNS:
   contour_levels_range: [-10, 300, 20]
   diff_colormap: "BrBG"
   diff_contour_range: [-24, 24, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2153,8 +1683,6 @@ FSNSC:
   contour_levels_range: [-10, 300, 20]
   diff_colormap: "BrBG"
   diff_contour_range: [-24, 24, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2171,8 +1699,6 @@ FLDS:
   contour_levels_range: [100, 500, 25]
   diff_colormap: "BrBG"
   diff_contour_range: [-20, 20, 2]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2204,8 +1730,6 @@ LHFLX:
   contour_levels_range: [0, 220, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-45, 45, 5]
-  scale_factor: 1
-  add_offset: 0
   new_unit: "Wm$^{-2}$"
   mpl:
     colorbar:
@@ -2331,8 +1855,6 @@ CLDTOT_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -2344,8 +1866,6 @@ CLDHGH_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -2357,8 +1877,6 @@ CLDMED_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -2370,8 +1888,6 @@ CLDLOW_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -2383,8 +1899,6 @@ CLD_CAL:
   contour_levels_range: [0, 105, 5]
   diff_colormap: "RdBu_r"
   diff_contour_range: [-40, 40, 5]
-  scale_factor: 1.
-  add_offset: 0
   new_unit: "Percent"
   obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
   obs_name: "CALIPSO"
@@ -2399,8 +1913,6 @@ CLD_CAL:
 H2O:
   colormap: "PuOr_r"
   diff_colormap: "BrBG"
-  scale_factor: 1
-  add_offset: 0
   new_unit: "mol mol$^{-1}$"
   mpl:
     colorbar:

--- a/lib/adf_variable_defaults_era5-1deg.yaml
+++ b/lib/adf_variable_defaults_era5-1deg.yaml
@@ -1118,8 +1118,8 @@ TGCLDLWP:
   category: "Clouds"
   obs_file: "TGCLDLWP_ERA5_monthly_climo_1degree_197901-202112.nc"
   obs_name: "ERA5"
-  derivable_from_obs: ['TGCLDWP']
-  derivation_formula_obs: "TGCLDWP * 1000"
+  obs_derivable_from: ['TGCLDWP']
+  obs_derivation_formula: "TGCLDWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1135,8 +1135,8 @@ TGCLDIWP:
   category: "Clouds"
   obs_file: "TGCLDIWP_ERA5_monthly_climo_1degree_197901-202112.nc"
   obs_name: "ERA5"
-  derivable_from_obs: ['TGCLDIWP']
-  derivation_formula_obs: "TGCLDIWP * 1000"
+  obs_derivable_from: ['TGCLDIWP']
+  obs_derivation_formula: "TGCLDIWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 

--- a/lib/adf_variable_defaults_era5-1deg.yaml
+++ b/lib/adf_variable_defaults_era5-1deg.yaml
@@ -1111,8 +1111,6 @@ TGCLDLWP:
   contour_levels_range: [0, 400, 10]
   diff_colormap: "BrBG"
   diff_contour_range: [-100, 100, 10]
-  scale_factor: 1000
-  add_offset: 0
   new_unit: "g m$^{-2}$"
   mpl:
     colorbar:
@@ -1120,9 +1118,8 @@ TGCLDLWP:
   category: "Clouds"
   obs_file: "TGCLDLWP_ERA5_monthly_climo_1degree_197901-202112.nc"
   obs_name: "ERA5"
-  obs_var_name: "TGCLDLWP"
-  obs_scale_factor: 1000
-  obs_add_offset: 0
+  derivable_from_obs: ['TGCLDWP']
+  derivation_formula_obs: "TGCLDWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1131,8 +1128,6 @@ TGCLDIWP:
   contour_levels_range: [0, 100, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-50, 50, 5]
-  scale_factor: 1000
-  add_offset: 0
   new_unit: "g m$^{-2}$"
   mpl:
     colorbar:
@@ -1140,9 +1135,8 @@ TGCLDIWP:
   category: "Clouds"
   obs_file: "TGCLDIWP_ERA5_monthly_climo_1degree_197901-202112.nc"
   obs_name: "ERA5"
-  obs_var_name: "TGCLDIWP"
-  obs_scale_factor: 1000
-  obs_add_offset: 0
+  derivable_from_obs: ['TGCLDIWP']
+  derivation_formula_obs: "TGCLDIWP * 1000"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
@@ -1245,6 +1239,7 @@ PRECT:
   obs_var_name: "PRECT"
   category: "Hydrologic cycle"
   derivable_from: ['PRECL','PRECC']
+  derivation_formula: "PRECC + PRECL"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 

--- a/lib/adf_variable_defaults_era5-1deg.yaml
+++ b/lib/adf_variable_defaults_era5-1deg.yaml
@@ -2010,8 +2010,6 @@ SWCF:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_sw_mon"
-  obs_scale_factor: 1
-  obs_add_offset: 0
   category: "TOA energy flux"
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"

--- a/lib/adf_variable_defaults_noresm.yaml
+++ b/lib/adf_variable_defaults_noresm.yaml
@@ -173,8 +173,8 @@ cb_BC:
   obs_file: "BURDENBC_MERRA2_monthly_climo_1degree_200001-202506.nc"
   obs_var_name: "BURDENBC"
   obs_name: "MERRA2"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
+  derivable_from_obs: ['BURDENBC']
+  derivation_formula_obs: "BURDENBC * 1e6"
 
 cb_SULFATE:
   category: "Aerosols"
@@ -190,8 +190,8 @@ cb_SULFATE:
   obs_file: "BURDENSO4_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_name: "CAMS"
   obs_var_name: "BURDENSO4"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
+  derivable_from_obs: ['BURDENSO4']
+  derivation_formula_obs: "BURDENSO4 * 1e6"
 
 cb_isoprene:
   category: "Aerosols"
@@ -242,8 +242,8 @@ cb_DUST:
   obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENDUST"
   obs_name: "CAMS"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
+  derivable_from_obs: ['BURDENDUST']
+  derivation_formula_obs: "BURDENDUST * 1e6"
 
 cb_OM:
   category: "Aerosols"
@@ -287,8 +287,8 @@ cb_SALT:
   obs_file: "BURDENSEASALT_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENSEASALT"
   obs_name: "CAMS"
-  obs_scale_factor: 1000000
-  obs_add_offset: 0
+  derivable_from_obs: ['BURDENSEASALT']
+  derivation_formula_obs: "BURDENSEASALT * 1e6"
 
 cb_SO2:
   category: "Aerosols"

--- a/lib/adf_variable_defaults_noresm.yaml
+++ b/lib/adf_variable_defaults_noresm.yaml
@@ -173,8 +173,8 @@ cb_BC:
   obs_file: "BURDENBC_MERRA2_monthly_climo_1degree_200001-202506.nc"
   obs_var_name: "BURDENBC"
   obs_name: "MERRA2"
-  derivable_from_obs: ['BURDENBC']
-  derivation_formula_obs: "BURDENBC * 1e6"
+  obs_derivable_from: ['BURDENBC']
+  obs_derivation_formula: "BURDENBC * 1e6"
 
 cb_SULFATE:
   category: "Aerosols"
@@ -190,8 +190,8 @@ cb_SULFATE:
   obs_file: "BURDENSO4_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_name: "CAMS"
   obs_var_name: "BURDENSO4"
-  derivable_from_obs: ['BURDENSO4']
-  derivation_formula_obs: "BURDENSO4 * 1e6"
+  obs_derivable_from: ['BURDENSO4']
+  obs_derivation_formula: "BURDENSO4 * 1e6"
 
 cb_isoprene:
   category: "Aerosols"
@@ -242,8 +242,8 @@ cb_DUST:
   obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENDUST"
   obs_name: "CAMS"
-  derivable_from_obs: ['BURDENDUST']
-  derivation_formula_obs: "BURDENDUST * 1e6"
+  obs_derivable_from: ['BURDENDUST']
+  obs_derivation_formula: "BURDENDUST * 1e6"
 
 cb_OM:
   category: "Aerosols"
@@ -287,8 +287,8 @@ cb_SALT:
   obs_file: "BURDENSEASALT_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENSEASALT"
   obs_name: "CAMS"
-  derivable_from_obs: ['BURDENSEASALT']
-  derivation_formula_obs: "BURDENSEASALT * 1e6"
+  obs_derivable_from: ['BURDENSEASALT']
+  obs_derivation_formula: "BURDENSEASALT * 1e6"
 
 cb_SO2:
   category: "Aerosols"

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -774,8 +774,11 @@ def make_polar_plot(wks, case_nickname,
     ax1.set_title(case_title, loc='left', fontsize=6) #fontsize=tiFontSize
 
     if obs:
-        obs_var = kwargs["obs_var_name"]
-        obs_title = kwargs["obs_file"][:-3]
+        # obs_var_name is optional (e.g. when the obs variable is defined by a
+        # derivation formula rather than a stored variable); default to blank.
+        obs_var = kwargs.get("obs_var_name", "")
+        _obs_file = kwargs.get("obs_file", "")
+        obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
         ax2.set_title(base_title, loc='left', fontsize=6) #fontsize=tiFontSize
     else:
@@ -1021,8 +1024,11 @@ def plot_map_vect_and_save(wks, case_nickname, base_nickname,
     ax[0].set_title(case_title, loc='left', fontsize=tiFontSize)
 
     if obs:
-        obs_var = kwargs["obs_var_name"]
-        obs_title = kwargs["obs_file"][:-3]
+        # obs_var_name is optional (e.g. when the obs variable is defined by a
+        # derivation formula rather than a stored variable); default to blank.
+        obs_var = kwargs.get("obs_var_name", "")
+        _obs_file = kwargs.get("obs_file", "")
+        obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
         ax[1].set_title(base_title, loc='left', fontsize=tiFontSize)
     else:
@@ -1268,8 +1274,11 @@ def plot_map_and_save(wks, case_nickname, base_nickname,
     ax[0].set_title(case_title, loc='left', fontsize=tiFontSize)
 
     if obs:
-        obs_var = kwargs["obs_var_name"]
-        obs_title = kwargs["obs_file"][:-3]
+        # obs_var_name is optional (e.g. when the obs variable is defined by a
+        # derivation formula rather than a stored variable); default to blank.
+        obs_var = kwargs.get("obs_var_name", "")
+        _obs_file = kwargs.get("obs_file", "")
+        obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
         ax[1].set_title(base_title, loc='left', fontsize=tiFontSize)
     else:
@@ -1466,8 +1475,11 @@ def plot_zonal_mean_and_save(wks, case_nickname, base_nickname,
     case_title = r"$\mathbf{Test}:$"+f"{case_nickname}\nyears: {case_climo_yrs[0]}-{case_climo_yrs[-1]}"
 
     if obs:
-        obs_var = kwargs["obs_var_name"]
-        obs_title = kwargs["obs_file"][:-3]
+        # obs_var_name is optional (e.g. when the obs variable is defined by a
+        # derivation formula rather than a stored variable); default to blank.
+        obs_var = kwargs.get("obs_var_name", "")
+        _obs_file = kwargs.get("obs_file", "")
+        obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
     else:
         base_title = r"$\mathbf{Baseline}:$"+f"{base_nickname}\nyears: {baseline_climo_yrs[0]}-{baseline_climo_yrs[-1]}"
@@ -1716,8 +1728,11 @@ def plot_meridional_mean_and_save(wks, case_nickname, base_nickname,
     case_title = r"$\mathbf{Test}:$"+f"{case_nickname}\nyears: {case_climo_yrs[0]}-{case_climo_yrs[-1]}"
 
     if obs:
-        obs_var = kwargs["obs_var_name"]
-        obs_title = kwargs["obs_file"][:-3]
+        # obs_var_name is optional (e.g. when the obs variable is defined by a
+        # derivation formula rather than a stored variable); default to blank.
+        obs_var = kwargs.get("obs_var_name", "")
+        _obs_file = kwargs.get("obs_file", "")
+        obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
     else:
         base_title = r"$\mathbf{Baseline}:$"+f"{base_nickname}\nyears: {baseline_climo_yrs[0]}-{baseline_climo_yrs[-1]}"

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -774,9 +774,9 @@ def make_polar_plot(wks, case_nickname,
     ax1.set_title(case_title, loc='left', fontsize=6) #fontsize=tiFontSize
 
     if obs:
-        # obs_var_name is optional (e.g. when the obs variable is defined by a
-        # derivation formula rather than a stored variable); default to blank.
-        obs_var = kwargs.get("obs_var_name", "")
+        # obs_var_name is optional; fall back to the obs field's name (e.g. for a
+        # formula-derived obs field) so the title still names the variable.
+        obs_var = kwargs.get("obs_var_name") or getattr(d2, "name", "") or ""
         _obs_file = kwargs.get("obs_file", "")
         obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
@@ -1024,9 +1024,12 @@ def plot_map_vect_and_save(wks, case_nickname, base_nickname,
     ax[0].set_title(case_title, loc='left', fontsize=tiFontSize)
 
     if obs:
-        # obs_var_name is optional (e.g. when the obs variable is defined by a
-        # derivation formula rather than a stored variable); default to blank.
-        obs_var = kwargs.get("obs_var_name", "")
+        # obs_var_name is optional; when absent (e.g. a formula-derived obs field)
+        # fall back to the obs field's own name so the title still names the variable.
+        _ofld = locals().get("obsfld")
+        if _ofld is None:
+            _ofld = locals().get("uobsfld_nowrap")
+        obs_var = kwargs.get("obs_var_name") or getattr(_ofld, "name", "") or ""
         _obs_file = kwargs.get("obs_file", "")
         obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
@@ -1274,9 +1277,12 @@ def plot_map_and_save(wks, case_nickname, base_nickname,
     ax[0].set_title(case_title, loc='left', fontsize=tiFontSize)
 
     if obs:
-        # obs_var_name is optional (e.g. when the obs variable is defined by a
-        # derivation formula rather than a stored variable); default to blank.
-        obs_var = kwargs.get("obs_var_name", "")
+        # obs_var_name is optional; when absent (e.g. a formula-derived obs field)
+        # fall back to the obs field's own name so the title still names the variable.
+        _ofld = locals().get("obsfld")
+        if _ofld is None:
+            _ofld = locals().get("uobsfld_nowrap")
+        obs_var = kwargs.get("obs_var_name") or getattr(_ofld, "name", "") or ""
         _obs_file = kwargs.get("obs_file", "")
         obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
@@ -1475,9 +1481,9 @@ def plot_zonal_mean_and_save(wks, case_nickname, base_nickname,
     case_title = r"$\mathbf{Test}:$"+f"{case_nickname}\nyears: {case_climo_yrs[0]}-{case_climo_yrs[-1]}"
 
     if obs:
-        # obs_var_name is optional (e.g. when the obs variable is defined by a
-        # derivation formula rather than a stored variable); default to blank.
-        obs_var = kwargs.get("obs_var_name", "")
+        # obs_var_name is optional; fall back to the obs field's name (e.g. for a
+        # formula-derived obs field) so the title still names the variable.
+        obs_var = kwargs.get("obs_var_name") or getattr(bdata, "name", "") or ""
         _obs_file = kwargs.get("obs_file", "")
         obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"
@@ -1728,9 +1734,9 @@ def plot_meridional_mean_and_save(wks, case_nickname, base_nickname,
     case_title = r"$\mathbf{Test}:$"+f"{case_nickname}\nyears: {case_climo_yrs[0]}-{case_climo_yrs[-1]}"
 
     if obs:
-        # obs_var_name is optional (e.g. when the obs variable is defined by a
-        # derivation formula rather than a stored variable); default to blank.
-        obs_var = kwargs.get("obs_var_name", "")
+        # obs_var_name is optional; fall back to the obs field's name (e.g. for a
+        # formula-derived obs field) so the title still names the variable.
+        obs_var = kwargs.get("obs_var_name") or getattr(bdata, "name", "") or ""
         _obs_file = kwargs.get("obs_file", "")
         obs_title = _obs_file[:-3] if _obs_file.endswith(".nc") else _obs_file
         base_title = r"$\mathbf{Baseline}:$"+obs_title+"\n"+r"$\mathbf{Variable}:$"+f"{obs_var}"

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -170,7 +170,21 @@ def meridional_mean(adfobj):
                     continue
 
                 #Extract variable of interest
-                odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions
+                if adfobj.compare_obs and data_var not in oclim_ds:
+                    # Derived obs variable (e.g. ALBEDO from solar_mon/fsnt): the obs
+                    # file stores the constituents, not the field itself, so build it
+                    # from derivation_formula_obs.  The formula already encodes any unit
+                    # scaling, so obs_scale_factor/obs_add_offset are skipped below.
+                    odata = adfobj.data.derive_obs_from_formula(oclim_ds, var)
+                    if odata is None:
+                        warnings.warn(f"obs variable {var} not found and not derivable, "
+                                      f"skipping meridional mean plot of {var}")
+                        continue
+                    odata = odata.squeeze()
+                    derived_obs = True
+                else:
+                    odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions
+                    derived_obs = False
                 mdata = mclim_ds[var].squeeze()
 
                 # APPLY UNITS TRANSFORMATION IF SPECIFIED:
@@ -184,8 +198,9 @@ def meridional_mean(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
-                # Or for observations
-                else:
+                # Or for observations (skip scaling when the obs field was built by a
+                # formula, which already encodes any conversion)
+                elif not derived_obs:
                     odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
                     # Note: we are going to assume that the specification ensures the conversion makes the units the same.
                     #       Doesn't make sense to add a different unit.

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -173,7 +173,7 @@ def meridional_mean(adfobj):
                 if adfobj.compare_obs and data_var not in oclim_ds:
                     # Derived obs variable (e.g. ALBEDO from solar_mon/fsnt): the obs
                     # file stores the constituents, not the field itself, so build it
-                    # from derivation_formula_obs.  The formula already encodes any unit
+                    # from obs_derivation_formula.  The formula already encodes any unit
                     # scaling, so obs_scale_factor/obs_add_offset are skipped below.
                     odata = adfobj.data.derive_obs_from_formula(oclim_ds, var)
                     if odata is None:


### PR DESCRIPTION
### Summary: 

When ADF compares the model against observations, it needs the obs data for each variable — but that data isn't always sitting in the obs file ready to use. Sometimes the file has the ingredients but not the final field (it stores the two kinds of rain, `PRECC` and `PRECL`, but not total rain `PRECT`). Sometimes the variable is stored under a different name, or in different units than the model uses. Until now, ADF could only rename a variable and multiply it by a fixed
number, which wasn't enough to cover these cases. 

This PR lets you write a short **formula** that tells ADF how to construct the observational variable from whatever the file actually contains. For example:

- `PRECT = PRECC + PRECL` — add the pieces together
- `ALBEDO = (solar_mon − fsnt) / solar_mon` — a genuine calculation
- `TGCLDLWP = TGCLDWP × 1000` — rename *and* convert units at once

### What you put in a variable's settings

Two new settings do the work, and one existing setting now has a clearer, narrower role:

| Setting | What it's for | When you use it |
|---------|---------------|-----------------|
| `obs_var_name` | The name the variable is stored under **in the obs file** | **Only** when the obs file stores the field directly but calls it something different from ADF (e.g. ADF's `AODVIS` is `AOD_550` in the file). Skip it when the name already matches, and skip it for derived variables — there's no single stored field to point at. |
| `obs_derivable_from` *(new)* | The list of input variables, **named as they appear in the obs file**, that the formula needs | When the variable has to be *built* from other fields in the file |
| `obs_derivation_formula` *(new)* | The formula itself, written in terms of those input names | Alongside `obs_derivable_from` — the two go together |

So it's an either/or: a variable that's **stored directly** may just need `obs_var_name` (if the name differs); a variable that's **computed** uses `obs_derivable_from` + `obs_derivation_formula` and leaves `obs_var_name` out
entirely. A quick example of the derived case:

```yaml
ALBEDO:
  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
  obs_name: "CERES-EBAF"
  obs_derivable_from: ['solar_mon', 'fsnt']          # what's actually in the file
  obs_derivation_formula: "(solar_mon - fsnt) / solar_mon"
```