### PR TITLE
new top level plotting directory

### DIFF
--- a/config_noresm_template.yaml
+++ b/config_noresm_template.yaml
@@ -30,13 +30,13 @@ diag_cam_climo:
     cam_case_name: ${case}
     case_nickname: ${nick}
     cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_climo.cam_case_name}/atm/hist
-    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo/s${diag_cam_climo.start_year}-e${diag_cam_climo.end_year}
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo
     start_year: 960
     end_year: 969
     cam_ts_done: false
     cam_ts_save: true
     cam_overwrite_ts: false
-    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries/s${diag_cam_climo.start_year}-e${diag_cam_climo.end_year}
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries
     tem_hist_str: cam.h4
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/tem/
     overwrite_tem: false
@@ -49,13 +49,13 @@ diag_cam_baseline_climo:
     cam_case_name: ${case_base}
     case_nickname: ${nick_base}
     cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_baseline_climo.cam_case_name}/atm/hist
-    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo/s${diag_cam_baseline_climo.start_year}-e${diag_cam_baseline_climo.end_year}
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo
     start_year: 960
     end_year: 969
     cam_ts_done: false
     cam_ts_save: false
     cam_overwrite_ts: false
-    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/tseries/s${diag_cam_baseline_climo.start_year}-e${diag_cam_baseline_climo.end_year}
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/tseries
     tem_hist_str: cam.h4
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/tem/
     overwrite_tem: false

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1157,7 +1157,10 @@ class AdfDiag(AdfWeb):
         # Working dir and output dir can be different. These could be set in config.yaml
         # but then we don't get the nicely formated plot_location
         case_idx = 0
-        plot_path = os.path.join(self.plot_location[case_idx], "mdtf")
+        # plot_location points at the "plots" subdirectory; MDTF output belongs
+        # at the case level (a sibling of "plots"/"website"), which is where the
+        # website links to it via "../mdtf".
+        plot_path = os.path.join(os.path.dirname(self.plot_location[case_idx]), "mdtf")
         for var in ["WORKING_DIR", "OUTPUT_DIR"]:
             mdtf_info[var] = plot_path
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -530,9 +530,12 @@ class AdfInfo(AdfConfig):
             #Update case name with provided/found years:
             case_name += f"_{syear}_{eyear}"
 
-            #Set the final directory name and save it to plot_location:
+            #Set the final directory name and save it to plot_location.
+            #Plots and tables are written to a "plots" subdirectory of the case
+            #directory so that the "website" subdirectory (a sibling of "plots")
+            #is not buried at the bottom of a long list of PNG files.
             direc_name = f"{case_name}_vs_{data_name}"
-            plot_loc = os.path.join(plot_dir, direc_name)
+            plot_loc = os.path.join(plot_dir, direc_name, "plots")
             self.__plot_location.append(plot_loc)
 
             #If first iteration, then save directory name for use by baseline:
@@ -556,7 +559,7 @@ class AdfInfo(AdfConfig):
         #generator.  These files will be stored in the same location as the first
         #listed case.
         if not self.compare_obs:
-            self.__plot_location.append(os.path.join(plot_dir, first_case_dir))
+            self.__plot_location.append(os.path.join(plot_dir, first_case_dir, "plots"))
         #End if
         #-------------------------------------------------------------------------
 

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -182,6 +182,16 @@ class AdfObs(AdfInfo):
                  "obs_add_offset" : obs_spec.get("obs_add_offset", 0),
                  "obs_derivable_from" : obs_spec.get("obs_derivable_from"),
                  "obs_derivation_formula" : obs_spec.get("obs_derivation_formula")}
+
+            #Copy the chosen observation's file name and variable name up to this
+            #variable's top-level defaults. The plotting code labels the "Baseline"
+            #panel of an obs comparison (e.g. "Baseline: ERAI_all_climo") by reading
+            #'obs_file' and 'obs_var_name' from the variable's defaults. Those keys
+            #used to sit at the top level but now live inside the 'obs_datasets'
+            #list, so we copy the selected dataset's values back up here --
+            #otherwise the plots show no observation source name.
+            default_var_dict["obs_file"] = obs_file_path.name
+            default_var_dict["obs_var_name"] = obs_var_name
         #End for (var)
 
         #If variable dictionary is still empty, then print warning to screen:

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -131,8 +131,10 @@ class AdfWeb(AdfObs):
             #Create new path object from user-specified plot directory path:
             plot_path = Path(self.plot_location[case_idx])
 
-            #Create directory path where the website will be built:
-            website_dir = plot_path / "website"
+            #Create directory path where the website will be built.
+            #plot_location points at the "plots" subdirectory, so the website is
+            #placed one level up (a sibling of "plots") in the case directory.
+            website_dir = plot_path.parent / "website"
 
             #Create a directory path that will hold just the html files for individual images:
             img_pages_dir = website_dir / "html_img"
@@ -198,8 +200,10 @@ class AdfWeb(AdfObs):
         if self.create_html and self.debug_log:
             plot_path = Path(self.plot_location[0])
 
-            #Create directory path where the website will be built:
-            website_dir = plot_path / "website"
+            #Create directory path where the website will be built.
+            #plot_location points at the "plots" subdirectory, so the website is
+            #placed one level up (a sibling of "plots") in the case directory.
+            website_dir = plot_path.parent / "website"
             Path(website_dir).mkdir(parents=True, exist_ok=True)
             run_info = f"{website_dir}/{run_info}"
             self._write_run_info_to_web(run_info, config_file, active_env)


### PR DESCRIPTION
Addresses #40. Previously, all plot PNGs and tables were written directly into the case directory alongside the `website/` subdirectory. Because `ls` sorts by ASCII and plot files start with uppercase variable names, `website/` (lowercase `w`)
sorted to the very end of a long list of PNGs and was hard to find.

The new layout is as follows:
```
{case}_{syrs}_vs_{data}/
    plots/      <- all PNGs and tables (plot_location now points here)
    website/    <- the generated website (sibling of plots)
    mdtf/       <- MDTF output, if enabled (sibling of plots/website)
```

Also resolves #39 - restore observation source name on baseline plot panels.




