### PR TITLE
 global_mean_timeseries: obs support and optional full-range time series

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -111,6 +111,7 @@ Settings shared by all runs.
 | `central_longitude` | optional | `180` | Center longitude for lat/lon maps. |
 | `num_procs` | optional | `1` | Processors for parallel steps. `"*"` = all on the node. Does **not** affect SE regrid (that runs serially). |
 | `redo_plot` | optional | `false` | `true` = remake plots even if they exist. |
+| `global_mean_ts_full_range` | optional | `false` | `true` = also generate time series over the **full available year range** (2-D variables only) for the `global_mean_timeseries` drift plot, so its model line(s) span the whole run rather than just the `start_year`–`end_year` climo window. Only takes effect when `global_mean_timeseries` is in `plotting_scripts`; applies to the test case(s) and the baseline (skipped for obs, which has no time series). Cases whose full range already equals the climo range are reused (no extra pass). The full-range series are written to a sibling `s<start>-e<end>` subdirectory of `cam_ts_loc`. |
 
 ---
 

--- a/config_noresm_template_base.yaml
+++ b/config_noresm_template_base.yaml
@@ -1,0 +1,199 @@
+user: 'mvertens'
+case: 'n1850.ne16pg3_tn14.noresm3_0_beta22.i486.2026-07-31'
+nick: 'testcase'
+case_base: 'n1850.ne16pg3_tn14.noresm3_0_beta22.bdmc2_1p2.20260730'
+nick_base: 'refcase'
+
+# baseic diagnostic info
+diag_basic_info:
+    compare_obs: false
+    global_mean_ts_full_range: true 
+    obs_source: "ERA5_1deg"      # match an obs_name; omit to use each variable's default
+    create_html: true
+    defaults_overlay_file: adf_variable_defaults_noresm.yaml
+    obs_data_loc: /nird/datalake/NS16000B/ADF-obs
+    cam_regrid_loc: /scratch/${user}/noresm3/${diag_cam_climo.cam_case_name}/atm/proc/tseries/regrid
+    cam_overwrite_regrid: false
+    cam_se_grid: ne16
+    cam_se_weight_file_ne16: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne16pg3_to_1.9x2.5_nomask_scripgrids_c250425.nc
+    cam_se_weight_file_ne30: /nird/datalake/NS9560K/diagnostics/land_xesmf_diag_data/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc
+    cam_diag_plot_loc: /nird/datalake/NS9560K/www/diagnostics/noresm/${user}/${case}/ADF
+    plot_press_levels: [200,500,850]
+    central_longitude: 180
+    num_procs: 8
+    redo_plot: true
+
+# info for target diagnostic case
+diag_cam_climo:
+    hist_str: cam.h0a
+    calc_cam_climo: true
+    cam_overwrite_climo: false
+    cam_case_name: ${case}
+    case_nickname: ${nick}
+    cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_climo.cam_case_name}/atm/hist
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/climo
+    start_year: 1140
+    end_year: 1149
+    cam_ts_done: false
+    cam_ts_save: true
+    cam_overwrite_ts: false
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries
+    tem_hist_str: cam.h4
+    cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/tem/
+    overwrite_tem: false
+
+# info for baseline compare if not comparing to observations
+diag_cam_baseline_climo:
+    hist_str: cam.h0a
+    calc_cam_climo: true
+    cam_overwrite_climo: false
+    cam_case_name: ${case_base}
+    case_nickname: ${nick_base}
+    cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_baseline_climo.cam_case_name}/atm/hist
+    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo
+    start_year: 1200
+    end_year: 1209
+    cam_ts_done: false
+    cam_ts_save: false
+    cam_overwrite_ts: false
+    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/tseries
+    tem_hist_str: cam.h4
+    cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/tem/
+    overwrite_tem: false
+
+# don't run cvdp
+diag_cvdp_info:
+    cvdp_run: false
+
+# don't run mdtf
+diag_mdtf_info:
+    mdtf_run: false
+
+# any of the scripts in scripts/averaging without the .py extension
+time_averaging_scripts:
+    - create_climo_files
+
+# any of the scripts in scripts/regridding without the .py extension
+regridding_scripts:
+    - regrid_and_vert_interp
+
+# any of the scripts in scripts/analysis without the .py extension
+analysis_scripts:
+    - amwg_table
+   #- ENSO_acrossRuns
+   #- aerosol_gas_tables
+
+# any of the scripts in scripts/plotting without the .py extension
+plotting_scripts:
+    - global_mean_timeseries
+    - global_latlon_map
+    - zonal_mean
+    - meridional_mean
+    - cam_taylor_diagram
+  # - global_latlon_vect_map
+  # - polar_map
+  # - qbo
+  # - ozone_diagnostics
+  # - enso_comparison_plots
+  # - tape_recorder
+  # - tem
+  # - regional_map_multicase #To use this please un-comment and fill-out
+                             #the "region_multicase" section below
+
+# variables to diagnose and plot
+diag_var_list:
+    - AODVIS
+    - mmr_BC
+    - mmr_DUST
+    - mmr_OM
+    - mmr_SALT
+    - mmr_SULFATE
+  # - D550_BC
+  # - D550_DU
+  # - D550_POM
+  # - D550_SO4
+  # - D550_SS
+    - cb_SULFATE
+    - cb_isoprene
+    - cb_monoterp
+    - cb_DUST
+    - cb_DMS
+    - cb_BC
+    - cb_OM
+    - cb_H2O2
+    - cb_H2SO4
+    - cb_SALT
+    - cb_SO2
+    - SFmonoterp
+    - SFisoprene
+    - SFSS
+    - SFSO4
+    - SFSO2_net
+    - SFOM
+    - SFBC
+    - SFDMS
+    - SFH2O2
+    - SFH2SO4
+    - CLDHGH
+    - CLDICE
+    - CLDLIQ
+    - CLDLOW
+    - CLDMED
+    - CLDTOT
+    - CLOUD
+    - RESTOM
+    - ALBEDOSURF
+    - TOTCF 
+    - FLNS
+    - FLNSC
+    - FLNT
+    - FLNTC
+    - FLUS
+    - FLDS
+    - FSDS
+    - FSDSC
+    - FSNS
+    - FSNT
+    - FSNTC
+    - FSUS
+    - LHFLX
+    - LWCF
+    - PBLH
+    - PRECT
+    - PS
+    - PSL
+    - QFLX
+    - RELHUM
+    - SHFLX
+    - SWCF
+    - T
+    - TAUX
+    - TAUY
+    - TGCLDIWP
+    - TGCLDLWP
+    - TMQ
+    - TREFHT
+    - TS
+    - U
+    - U10
+    - ICEFRAC
+    - OCNFRAC
+    - LANDFRAC
+    - ALBEDO
+    - ALBEDOC
+
+# <Add more variables here.>
+
+# Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# for region_time_option - if calendar, will look for specified years, if zeroanchor
+#  will use a nyears starting from year_offset from the beginning of timeseries
+# region_multicase:
+#     region_spec: [slat, nlat, wlon, elon]
+#     region_time_option: <calendar | zeroanchor>
+#     region_start_year:
+#     region_end_year:
+#     region_nyear:
+#     region_year_offset:
+#     region_month: <NULL means look for season>
+#     region_season: <NULL means use annual mean>
+#     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>

--- a/config_noresm_template_obs.yaml
+++ b/config_noresm_template_obs.yaml
@@ -1,12 +1,11 @@
 user: '<user name>'
 case: '<case name>'
 nick: '<case nickname>'
-case_base: 'baseline case name>'
-nick_base: 'baseline case nickname>'
 
 # baseic diagnostic info
 diag_basic_info:
-    compare_obs: false
+    compare_obs: true
+    global_mean_ts_full_range: true
     obs_source: "ERA5_1deg"      # match an obs_name; omit to use each variable's default
     create_html: true
     defaults_overlay_file: adf_variable_defaults_noresm.yaml
@@ -39,25 +38,6 @@ diag_cam_climo:
     cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/atm/proc/tseries
     tem_hist_str: cam.h4
     cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_climo.cam_case_name}/tem/
-    overwrite_tem: false
-
-# info for baseline compare if not comparing to observations
-diag_cam_baseline_climo:
-    hist_str: cam.h0a
-    calc_cam_climo: true
-    cam_overwrite_climo: false
-    cam_case_name: ${case_base}
-    case_nickname: ${nick_base}
-    cam_hist_loc: /nird/datalake/NS9560K/noresm3/cases/${diag_cam_baseline_climo.cam_case_name}/atm/hist
-    cam_climo_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/climo
-    start_year: 960
-    end_year: 969
-    cam_ts_done: false
-    cam_ts_save: false
-    cam_overwrite_ts: false
-    cam_ts_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/atm/proc/tseries
-    tem_hist_str: cam.h4
-    cam_tem_loc: /scratch/${user}/noresm3/ADF/${diag_cam_baseline_climo.cam_case_name}/tem/
     overwrite_tem: false
 
 # don't run cvdp

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -127,16 +127,24 @@ class AdfData:
     # Time series files
     #------------------
     # Test case(s)
-    def get_timeseries_file(self, case, field, hist_str=None):
+    def get_timeseries_file(self, case, field, hist_str=None, full_range=False):
         """Return list of test time series files.
 
         If hist_str is given, restrict the search to that history stream
         (time series files are named {case}.{hist_str}.{field}.*.nc).
+
+        If full_range is True, look in the full-range year-stamped subdirectory
+        (a sibling of the climo-range one) written by
+        create_time_series(full_range=True) -- used by the global-mean drift plot.
         """
         # list of paths (could be multiple cases)
         ts_locs = self.adf.get_cam_info("cam_ts_loc", required=True)
         caseindex = (self.case_names).index(case)
         ts_loc = Path(ts_locs[caseindex])
+        if full_range:
+            syr = self.adf.climo_yrs["syears_all"][caseindex]
+            eyr = self.adf.climo_yrs["eyears_all"][caseindex]
+            ts_loc = ts_loc.parent / f"s{syr}-e{eyr}"
         if hist_str:
             ts_filenames = f'{case}.{hist_str}.{field}.*nc'
         else:
@@ -145,16 +153,23 @@ class AdfData:
         return ts_files
 
     # Reference case (baseline/obs)
-    def get_ref_timeseries_file(self, field, hist_str=None):
+    def get_ref_timeseries_file(self, field, hist_str=None, full_range=False):
         """Return list of reference time series files.
 
         If hist_str is given, restrict the search to that history stream.
+
+        If full_range is True, look in the full-range year-stamped subdirectory
+        written by create_time_series(baseline=True, full_range=True).
         """
         if self.adf.compare_obs:
             warnings.warn("\t    WARNING: ADF does not currently expect "
                           "observational time series files.")
             return None
         ts_loc = Path(self.adf.get_baseline_info("cam_ts_loc", required=True))
+        if full_range:
+            syr = self.adf.climo_yrs["syear_baseline_all"]
+            eyr = self.adf.climo_yrs["eyear_baseline_all"]
+            ts_loc = ts_loc.parent / f"s{syr}-e{eyr}"
         if hist_str:
             ts_filenames = f'{self.ref_case_label}.{hist_str}.{field}.*nc'
         else:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -323,9 +323,17 @@ class AdfDiag(AdfWeb):
 
     #########
 
-    def create_time_series(self, baseline=False):
+    def create_time_series(self, baseline=False, full_range=False):
         """
         Generate time series versions of the CAM history file data.
+
+        If ``full_range`` is True, generate time series over the *full available*
+        year range (``climo_yrs[..._all]``) into a separate year-stamped
+        directory, and only for 2-D variables. This is the optional pass used by
+        the ``global_mean_ts_full_range`` time series so the global-mean drift
+        plot spans the whole run rather than just the climo window (see
+        ``run_adf_diag``). Cases whose full range already equals the climo range
+        are skipped (the normal pass already produced those files).
         """
 
         #Notify user that script has started:
@@ -369,6 +377,24 @@ class AdfDiag(AdfWeb):
             hist_str_list = self.hist_string["test_hist_str"]
         # End if
 
+        # For the optional "full range" pass, override the years and output
+        # directories: use the full available range (climo_yrs[..._all]) and a
+        # separate year-stamped subdirectory (sibling of the climo-range one).
+        # The climo years are kept so cases whose full range already equals the
+        # climo range can be skipped below.
+        climo_syears = start_years
+        climo_eyears = end_years
+        if full_range:
+            if baseline:
+                start_years = [self.climo_yrs["syear_baseline_all"]]
+                end_years = [self.climo_yrs["eyear_baseline_all"]]
+            else:
+                start_years = self.climo_yrs["syears_all"]
+                end_years = self.climo_yrs["eyears_all"]
+            ts_dirs = [os.path.join(os.path.dirname(str(d)), f"s{sy}-e{ey}")
+                       for d, sy, ey in zip(ts_dirs, start_years, end_years)]
+        # End if
+
         # Read hist_str (component.hist_num) from the yaml file, or set to default
         dmsg = f"reading from {hist_str_list} files"
         self.debug_log(dmsg)
@@ -396,6 +422,16 @@ class AdfDiag(AdfWeb):
             # Extract start and end year values:
             start_year = start_years[case_idx]
             end_year = end_years[case_idx]
+
+            # Full-range reuse: if the full available range already equals the
+            # climo range for this case, the normal (climo) pass already wrote
+            # these time series -- skip to avoid duplicating them.
+            if full_range and (str(climo_syears[case_idx]) == str(start_year)
+                               and str(climo_eyears[case_idx]) == str(end_year)):
+                print(f"\tNOTE: full range for '{case_name}' equals the climo range; "
+                      "reusing the existing time series.")
+                continue
+            # End if
 
             # Create path object for the CAM history file(s) location:
             starting_location = Path(cam_hist_locs[case_idx])
@@ -534,6 +570,16 @@ class AdfDiag(AdfWeb):
                 # Loop over CAM history variables:
                 ts_output_files = []  # native SE time-series files to regrid to lat/lon
                 for var in diag_var_list:
+                    # In the full-range pass, only 2-D variables are needed (the
+                    # global-mean time series plot skips 3-D fields), so skip any
+                    # variable that carries a vertical dimension.
+                    if full_range and var in hist_file_ds.variables:
+                        _vdims = hist_file_ds[var].dims
+                        if ("lev" in _vdims) or ("ilev" in _vdims):
+                            continue
+                        #End if
+                    #End if
+
                     # Notify user of new time series file:
                     print(f"\t - time series for {var}")
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -177,6 +177,8 @@ class AdfInfo(AdfConfig):
             #Set the baseline years to empty strings:
             syear_baseline = ""
             eyear_baseline = ""
+            syear_baseline_all = ""
+            eyear_baseline_all = ""
         else:
             #If not, then assume a CAM vs CAM run and add CAM baseline climatology info to object:
             self.__cam_bl_climo_info = self.read_config_var('diag_cam_baseline_climo',
@@ -191,6 +193,10 @@ class AdfInfo(AdfConfig):
             #Attempt to grab baseline start_years (not currently required):
             syear_baseline = self.get_baseline_info('start_year')
             eyear_baseline = self.get_baseline_info('end_year')
+
+            #Full available baseline range (for global_mean_ts_full_range).
+            baseline_full_syr = None
+            baseline_full_eyr = None
 
             #Get climo years for verification or assignment if missing
             baseline_hist_locs = self.get_baseline_info('cam_hist_loc')
@@ -213,6 +219,8 @@ class AdfInfo(AdfConfig):
                 #Get years from pre-made timeseries file(s)
                 found_syear_baseline, found_eyear_baseline = self.get_climo_yrs_from_ts(
                     input_ts_loc, data_name)
+                baseline_full_syr = int(found_syear_baseline)
+                baseline_full_eyr = int(found_eyear_baseline)
 
                 #History file path isn't needed if user is running ADF directly on time series.
                 #So make sure start and end year are specified:
@@ -298,6 +306,7 @@ class AdfInfo(AdfConfig):
                 print(f"AVAILABLE  YEARS IN BASE RUN: {base_climo_yrs}")
                 base_found_syr = int(base_climo_yrs[0])
                 base_found_eyr = int(base_climo_yrs[-1])
+                baseline_full_syr, baseline_full_eyr = base_found_syr, base_found_eyr
 
                 #Check if start or end year is missing. If so then just assume it is the
                 #start or end of the entire available model data.
@@ -345,6 +354,13 @@ class AdfInfo(AdfConfig):
             syear_baseline = int(syear_baseline)
             eyear_baseline = int(eyear_baseline)
 
+            #Record the full available baseline range (falls back to the climo
+            #range if a source did not report one).
+            if baseline_full_syr is None:
+                baseline_full_syr, baseline_full_eyr = syear_baseline, eyear_baseline
+            syear_baseline_all = int(baseline_full_syr)
+            eyear_baseline_all = int(baseline_full_eyr)
+
             #Stamp the baseline time-series and climo output locations with the
             #actual baseline years used (same reasoning as the test case above).
             _yr_subdir = f"s{syear_baseline}-e{eyear_baseline}"
@@ -365,6 +381,8 @@ class AdfInfo(AdfConfig):
         #Save starting and ending years as object variables:
         self.__syear_baseline = syear_baseline
         self.__eyear_baseline = eyear_baseline
+        self.__syear_baseline_all = syear_baseline_all
+        self.__eyear_baseline_all = eyear_baseline_all
 
         #Create plot location variable for potential use by the website generator.
         #Please note that this is also assumed to be the output location for the analyses scripts:
@@ -415,10 +433,17 @@ class AdfInfo(AdfConfig):
         #Loop over cases:
         syears_fixed = []
         eyears_fixed = []
+        #Full available year range per case (used by the optional
+        #global_mean_ts_full_range time series). Set from whichever source
+        #(pre-made time series or history files) reports the available years.
+        syears_all = []
+        eyears_all = []
         for case_idx, case_name in enumerate(case_names):
 
             syear = syears[case_idx]
             eyear = eyears[case_idx]
+            case_full_syr = None
+            case_full_eyr = None
 
             #Check if time series files exist, if so don't rely on climo years
             if cam_ts_done[case_idx]:
@@ -430,6 +455,7 @@ class AdfInfo(AdfConfig):
 
                 #Get years from pre-made timeseries file(s)
                 found_syear, found_eyear = self.get_climo_yrs_from_ts(input_ts_loc, case_name)
+                case_full_syr, case_full_eyr = int(found_syear), int(found_eyear)
 
                 #History file path isn't needed if user is running ADF directly on time series.
                 #So make sure start and end year are specified:
@@ -509,6 +535,7 @@ class AdfInfo(AdfConfig):
                 print(f'Case climo years: {case_climo_yrs}')
                 case_found_syr = int(case_climo_yrs[0])
                 case_found_eyr = int(case_climo_yrs[-1])
+                case_full_syr, case_full_eyr = case_found_syr, case_found_eyr
 
                 #Check if start or end year is missing.  If so then just assume it is the
                 #start or end of the entire available model data.
@@ -543,6 +570,12 @@ class AdfInfo(AdfConfig):
             eyear = int(eyear)
             syears_fixed.append(syear)
             eyears_fixed.append(eyear)
+            #Record the full available range (falls back to the climo range if a
+            #source did not report one).
+            if case_full_syr is None:
+                case_full_syr, case_full_eyr = syear, eyear
+            syears_all.append(int(case_full_syr))
+            eyears_all.append(int(case_full_eyr))
 
             #Stamp the time-series and climo output locations with the actual
             #years used (s<syear>-e<eyear>) as a subdirectory. This uses the years
@@ -584,6 +617,8 @@ class AdfInfo(AdfConfig):
 
         self.__syears = syears_fixed
         self.__eyears = eyears_fixed
+        self.__syears_all = syears_all
+        self.__eyears_all = eyears_all
 
         #Finally add baseline case (if applicable) for use by the website table
         #generator.  These files will be stored in the same location as the first
@@ -735,7 +770,12 @@ class AdfInfo(AdfConfig):
         syears = copy.copy(self.__syears) #Send copies so a script doesn't modify the original
         eyears = copy.copy(self.__eyears)
         return {"syears":syears,"eyears":eyears,
-                "syear_baseline":self.__syear_baseline, "eyear_baseline":self.__eyear_baseline}
+                "syear_baseline":self.__syear_baseline, "eyear_baseline":self.__eyear_baseline,
+                #Full available range (per test case, and the baseline), for the
+                #optional global_mean_ts_full_range time series.
+                "syears_all":copy.copy(self.__syears_all), "eyears_all":copy.copy(self.__eyears_all),
+                "syear_baseline_all":self.__syear_baseline_all,
+                "eyear_baseline_all":self.__eyear_baseline_all}
 
     # Create property needed to return the case nicknames to user:
     @property

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -173,6 +173,22 @@ if __name__ == "__main__":
     if not diag.compare_obs:
         diag.create_time_series(baseline=True)
 
+    #Optionally generate FULL-RANGE time series (over the full available years,
+    #2-D variables only) for the global-mean time series drift plot. This runs
+    #only when the 'global_mean_ts_full_range' toggle is set AND
+    #'global_mean_timeseries' is requested in 'plotting_scripts'. The full-range
+    #pass skips any case whose full range already equals its climo range.
+    _plot_scripts = diag.read_config_var("plotting_scripts") or []
+    _gm_requested = any(
+        ("global_mean_timeseries" in s) if isinstance(s, dict)
+        else (s == "global_mean_timeseries")
+        for s in _plot_scripts
+    )
+    if diag.get_basic_info("global_mean_ts_full_range") and _gm_requested:
+        diag.create_time_series(full_range=True)
+        if not diag.compare_obs:
+            diag.create_time_series(baseline=True, full_range=True)
+
     #Call the CVDP:
     if diag.get_cvdp_info('cvdp_run'):
        diag.setup_run_cvdp()

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -27,21 +27,12 @@ def global_mean_timeseries(adfobj):
     Include the CESM2 LENS result if it can be found.
     """
 
-    # Global-mean *time series* need reference data with an interannual time
-    # axis, i.e. a baseline simulation.  Observations in ADF are climatologies
-    # (12 monthly means, no year-to-year time axis), so there is nothing on the
-    # obs side to plot as a time series -- get_ref_timeseries_file() returns
-    # None for every variable in obs mode.  Rather than emit a "time series not
-    # found" warning for each variable, note it once and skip the whole script.
-    # This lets global_mean_timeseries stay enabled in a shared template config
-    # and simply no-op cleanly during model-vs-obs runs.
-    if adfobj.compare_obs:
-        print("\n  NOTE: 'global_mean_timeseries' compares the model's global-mean "
-              "time series against a baseline simulation, which requires reference "
-              "data with a multi-year time axis. This run compares against "
-              "observations (climatologies), which have no such time series, so "
-              "'global_mean_timeseries' is skipped.\n")
-        return
+    # The test case's own global-mean time series is always plotted. The
+    # *reference* drawn alongside it depends on the run type:
+    #   * model-vs-baseline: the baseline's global-mean time series (a line);
+    #   * model-vs-obs: observations are climatologies with no interannual time
+    #     axis, so the obs field's global, annual mean is drawn as a single
+    #     horizontal reference line instead of a series.
 
     emislist = ["SFmonoterp","SFisoprene","SFSS","SFDUST", "SFSOA", "SFSO4", "SFSO2_net", "SFOM", "SFBC", "SFDMS", "SFH2O2","SFH2SO4"]
     cblist=["cb_SULFATE","cb_isoprene","cb_monoterp","cb_DUST","cb_DMS","cb_BC","cb_OM","cb_H2O2","cb_H2SO4","cb_SALT", "cb_SO2"]
@@ -53,58 +44,72 @@ def global_mean_timeseries(adfobj):
     res = adfobj.variable_defaults
 
     for var in adfobj.diag_var_list:
-        ts_files = adfobj.data.get_ref_timeseries_file(var)#
-        # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
-        if not ts_files:
-            errmsg = f"Time series files for variable '{var}' not found.  Script will continue to next variable."
-            warnings.warn(errmsg)
-            continue
-        #End if
+        # Reference for this variable:
+        #   ref_ts_da : baseline global-mean time series (drawn as a line)
+        #   ref_hline : obs climatology global-annual mean (drawn as a horizontal line)
+        ref_ts_da = None
+        ref_hline = None
 
-        #TEMPORARY:  For now, make sure only one file exists:
-        if len(ts_files) != 1:
-            errmsg =  "Currently the AMWG table script can only handle one time series file per variable."
-            errmsg += f" Multiple files were found for the variable '{var}', so it will be skipped."
-            warnings.warn(errmsg)
-            continue
-        #End if
-
-        #Load model variable data from file:
-        ds = utils.load_dataset(ts_files)
-        ref_ts_da = ds[var]
-        
-        if var in emislist:
-            ref_ts_da = surface_emission(ref_ts_da)
-        elif var in cblist:
-            ref_ts_da_ga = column_burden(ref_ts_da)
-        # reference time series global average
+        if adfobj.compare_obs:
+            # Observations are climatologies (no interannual time axis), so collapse
+            # the obs field to a single global, annual mean and draw it as a
+            # horizontal reference line. Returns None for a variable with no obs or
+            # a vertical (3-D) dimension.
+            ref_hline = _obs_global_mean(adfobj, var)
         else:
-            # check data dimensions:
-            has_lat_ref, has_lev_ref = utils.zm_validate_dims(ref_ts_da)
-
-            # check if this is a "2-d" varaible:
-            if has_lev_ref:
-                warnings.warn(
-                    f"\t Variable named {var} has a lev dimension, which does not work with this script."
-                )
+            ts_files = adfobj.data.get_ref_timeseries_file(var)
+            # If no files exist, move on to the next variable.
+            if not ts_files:
+                errmsg = f"Time series files for variable '{var}' not found.  Script will continue to next variable."
+                warnings.warn(errmsg)
                 continue
-            # End if
-            
-            # check if there is a lat dimension:
-            if not has_lat_ref:
-                warnings.warn(
-                    f"\t Variable named {var} is missing a lat dimension, cannot continue to plot."
-                )                
-                continue
-            # End if
+            #End if
 
+            #TEMPORARY:  For now, make sure only one file exists:
+            if len(ts_files) != 1:
+                errmsg =  "Currently the AMWG table script can only handle one time series file per variable."
+                errmsg += f" Multiple files were found for the variable '{var}', so it will be skipped."
+                warnings.warn(errmsg)
+                continue
+            #End if
+
+            #Load reference (baseline) variable data from file:
+            ds = utils.load_dataset(ts_files)
+            ref_ts_da = ds[var]
+
+            if var in emislist:
+                ref_ts_da = surface_emission(ref_ts_da)
+            elif var in cblist:
+                ref_ts_da_ga = column_burden(ref_ts_da)
             # reference time series global average
-            ref_ts_da_ga = utils.spatial_average(ref_ts_da, weights=None, spatial_dims=None)
+            else:
+                # check data dimensions:
+                has_lat_ref, has_lev_ref = utils.zm_validate_dims(ref_ts_da)
 
-        # annually averaged
-        if var not in emislist:
-            ref_ts_da = utils.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
-        # End if
+                # check if this is a "2-d" varaible:
+                if has_lev_ref:
+                    warnings.warn(
+                        f"\t Variable named {var} has a lev dimension, which does not work with this script."
+                    )
+                    continue
+                # End if
+
+                # check if there is a lat dimension:
+                if not has_lat_ref:
+                    warnings.warn(
+                        f"\t Variable named {var} is missing a lat dimension, cannot continue to plot."
+                    )
+                    continue
+                # End if
+
+                # reference time series global average
+                ref_ts_da_ga = utils.spatial_average(ref_ts_da, weights=None, spatial_dims=None)
+
+            # annually averaged
+            if var not in emislist:
+                ref_ts_da = utils.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
+            # End if
+        # End if (compare_obs)
 
         # Loop over model cases:
         case_ts = {}  # dictionary of annual mean, global mean time series
@@ -178,10 +183,25 @@ def global_mean_timeseries(adfobj):
             case_ts[labels[case_name]] = c_ts_da_ga
 
 
+        # Nothing to plot if no test-case series were produced (e.g. all cases
+        # were 3-D or missing) -- skip the variable.
+        if not case_ts:
+            continue
+        #End if
+
+        # Reference label: the obs dataset name for obs runs, otherwise the
+        # baseline nickname.
+        if adfobj.compare_obs:
+            plot_ref_label = adfobj.data.ref_labels.get(var, ref_label)
+        else:
+            plot_ref_label = ref_label
+
         fig, ax = make_plot(
-            ref_ts_da, case_ts, var, label=adfobj.data.ref_nickname
+            ref_ts_da, case_ts, var, label=plot_ref_label, ref_hline=ref_hline
         )
-        ax.set_ylabel(getattr(ref_ts_da,"units", "[-]")) # add units
+        # Units: prefer the reference series, else fall back to a test-case series.
+        _units_src = ref_ts_da if ref_ts_da is not None else next(iter(case_ts.values()))
+        ax.set_ylabel(getattr(_units_src, "units", "[-]")) # add units
         plot_name = plot_loc / f"{var}_GlobalMean_ANN_TimeSeries_Mean.{plot_type}"
 
         conditional_save(adfobj, plot_name, fig)
@@ -339,12 +359,23 @@ def make_plot(case_ts, lens2, label=None, ref_ts_da=None):
     return plot_loc
 
 
-def make_plot(ref_ts_da, case_ts, var, label=None):
-    """plot yearly values of ref_ts_da"""
+def make_plot(ref_ts_da, case_ts, var, label=None, ref_hline=None):
+    """Plot the yearly test-case series, plus a reference.
+
+    The reference is one of:
+      * ``ref_ts_da`` -- a baseline global-mean time series, drawn as a line, or
+      * ``ref_hline`` -- an obs climatology global-annual mean, drawn as a single
+        horizontal reference line,
+    or neither (no reference available).
+    """
     fig, ax = plt.subplots()
-    ax.plot(ref_ts_da.year, ref_ts_da, label=label)
     for c, cdata in case_ts.items():
         ax.plot(cdata.year, cdata, label=c)
+    if ref_ts_da is not None:
+        ax.plot(ref_ts_da.year, ref_ts_da, label=label)
+    if ref_hline is not None:
+        hlabel = f"{label}: {float(ref_hline):.3g}" if label else f"{float(ref_hline):.3g}"
+        ax.axhline(y=float(ref_hline), color="k", linestyle="--", linewidth=1.5, label=hlabel)
     # Get the current y-axis limits
     ymin, ymax = ax.get_ylim()
     # Check if the y-axis crosses zero
@@ -365,6 +396,35 @@ def make_plot(ref_ts_da, case_ts, var, label=None):
 ##################
 # Helper functions
 ##################
+def _obs_global_mean(adfobj, var):
+    """Return the observational climatology's global, annual-mean value for ``var``
+    as a single scalar (for a horizontal reference line), or ``None`` if there is
+    no obs for the variable or it is not a 2-D field.
+
+    The obs field is loaded the same way the map/zonal plots load it
+    (``load_reference_regrid_da``), so unit conversions and any obs derivation are
+    applied. A plain mean over the climatology's time (month) dimension is used
+    rather than a calendar-weighted annual mean, so obs files with irregular time
+    coordinates do not cause failures -- this is a reference level, not a headline
+    statistic.
+    """
+    if var not in adfobj.data.ref_var_nam:
+        return None
+    base_name = adfobj.data.ref_labels.get(var)
+    oda = adfobj.data.load_reference_regrid_da(base_name, var)
+    if oda is None:
+        return None
+    # Skip fields with a vertical dimension -- this script is 2-D only.
+    has_lat, has_lev = utils.zm_validate_dims(oda)
+    if has_lev or not has_lat:
+        return None
+    ga = utils.spatial_average(oda, weights=None, spatial_dims=None)
+    try:
+        return float(ga.mean())
+    except (TypeError, ValueError):
+        return None
+
+
 def _get_area(tmp_file):
     """
     This function retrieves the files, latitude, and longitude information

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -43,6 +43,11 @@ def global_mean_timeseries(adfobj):
    
     res = adfobj.variable_defaults
 
+    # When 'global_mean_ts_full_range' is set, read time series from the
+    # full-range (whole run) subdirectory rather than the climo window, so the
+    # drift plot spans the entire run. See run_adf_diag / create_time_series.
+    full_range = bool(adfobj.get_basic_info("global_mean_ts_full_range"))
+
     for var in adfobj.diag_var_list:
         # Reference for this variable:
         #   ref_ts_da : baseline global-mean time series (drawn as a line)
@@ -57,7 +62,7 @@ def global_mean_timeseries(adfobj):
             # a vertical (3-D) dimension.
             ref_hline = _obs_global_mean(adfobj, var)
         else:
-            ts_files = adfobj.data.get_ref_timeseries_file(var)
+            ts_files = adfobj.data.get_ref_timeseries_file(var, full_range=full_range)
             # If no files exist, move on to the next variable.
             if not ts_files:
                 errmsg = f"Time series files for variable '{var}' not found.  Script will continue to next variable."
@@ -128,7 +133,7 @@ def global_mean_timeseries(adfobj):
             else adfobj.data.ref_case_label
         )
         for case_name in adfobj.data.case_names:
-            c_ts_files = adfobj.data.get_timeseries_file(case_name, var)
+            c_ts_files = adfobj.data.get_timeseries_file(case_name, var, full_range=full_range)
             # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
             if not c_ts_files:
                 errmsg = f"Time series files for case: {case_name} and variable '{var}' not found.  Script will continue to next variable."


### PR DESCRIPTION
### Summary

Two related improvements to the `global_mean_timeseries` (global-mean drift) plot:

**NOTE: there are two new template files:
config_noresm_template_base.yaml for baseline comparison
config_noresm_template_obs.yaml for observation comparison**

1. **Works under model-vs-obs.** Previously the plot was skipped entirely when comparing against observations. It now always plots the test case's global-mean time series, and draws the obs climatology's global-annual mean as a horizontal reference line.

2. **Optional full-range time series.** A new `global_mean_ts_full_range` toggle makes ADF generate time series over the *entire available* year range (not just the climatology window), so the drift plot's model line spans the whole run even when the climatology is computed over a subset of years. 

---

### 1. Global-mean time series under observations

`global_mean_timeseries` compares a global-mean *time series*, which needs a reference with an interannual time axis. Observations in ADF are climatologies (12 monthly means, no year-to-year axis), so the script — which was driven off a
reference time series — produced nothing under `compare_obs` and was skipped outright.

The test case's own global-mean series is now always plotted, and the reference adapts to the run type:

* **model-vs-baseline** — the baseline's global-mean time series (a line), as before;
* **model-vs-obs** — the obs field's global, annual mean, drawn as a single horizontal reference line labeled with the dataset name and value (e.g. `ERAI: 2.88`).

---

### 2. Optional full-range time series (`global_mean_ts_full_range`)

The climatology is often computed over a subset of the run (`start_year` /`end_year`), and time series are generated only for that window. A drift plot, however, is most useful over the *whole* run. This feature lets the drift plot span the full available range independently of the climatology window.

This new feature is now controlled by a single toggle in `diag_basic_info`:

```yaml
diag_basic_info:
    global_mean_ts_full_range: true
```

When it is set **and** `global_mean_timeseries` is listed in `plotting_scripts`, ADF generates an additional set of time series over the full available year range (2-D variables only), regridded to lat/lon like the normal pass, and the drift plot reads from those.

* Applies to the **test case(s)** and, for CAM-vs-CAM runs, the **baseline**.   In an obs run there is no baseline time series, so only the test case is processed (the obs side stays a horizontal line). * Runs on **2-D variables only** (`global_mean_timeseries` skips 3-D fields). 
* **Reuse:** if a case's full range already equals its climo range (years omitted), no extra pass is run for that case — the existing time series are used.

The full-range series are written to a **sibling year-stamped subdirectory** of the climatology-range one:
```
.../atm/proc/tseries/s<climo_start>-e<climo_end>/    # climo window (existing)
.../atm/proc/tseries/s<full_start>-e<full_end>/      # full range (new, this feature)
```
`global_mean_timeseries` always reads the full-range directory when the toggle is on; because the reuse case writes to the same directory name, the plot finds its series whether or not a separate pass ran.

## Notes / follow-ups

* **Units (part 1).** The obs horizontal line uses the converted obs, while the model series uses the raw time-series units (as this script has always done).  For a variable with a `new_unit`, the two could sit on different scales; worth a spot check (e.g. PRECT). If needed, applying the same conversion to the model series is a small follow-up.
* **Pre-made time series (`cam_ts_done`).** The full-range pass generates series from history files. If a case points at pre-made time series, there is nothing to generate, so the feature assumes ADF is building the series.