### PR TITLE
Fix global time series bug

### DIFF
--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -155,7 +155,8 @@ def check_derive(self, res, var, case_name, diag_var_list, constit_dict, hist_fi
 
 
 def derive_variable(self, case_name, var, res=None, ts_dir=None,
-                         constit_list=None, overwrite=None, hist_str=None):
+                         constit_list=None, overwrite=None, hist_str=None,
+                         syear=None, eyear=None):
     """
     Derive variables acccording to steps given here.  Since derivations will depend on the
     variable, each variable to derive will need its own set of steps below.
@@ -165,25 +166,35 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     If the file for the derived variable exists, the kwarg `overwrite` determines
     whether to overwrite the file (true) or exit with a warning message.
 
+    ``syear`` / ``eyear`` are the actual years of the pass being processed. When
+    given, the constituent time series are matched against ``syearMM-eyearMM`` in
+    ``ts_dir``. This is required for the full-range time series pass, whose files
+    are stamped with the full-range years rather than the climatology years; if
+    these are omitted the climatology range (``climo_yrs``) is used as a fallback.
     """
 
     # Loop through derived variables
     print(f"\t - deriving time series for {var}")
 
-    # Determine which case name / date-range slot to match constituents against
-    start_years = str(self.climo_yrs["syears"][0]).zfill(4)
-    end_years   = str(self.climo_yrs["eyears"][0]).zfill(4)
-    date_range_string_case = f"{start_years}01-{end_years}12"
-
-    # Match constituents against the case actually being processed (case_name).
-    if case_name == self.get_baseline_info("cam_case_name"):
+    # Determine which case name / date-range slot to match constituents against.
+    # Prefer the explicit years of this pass (correct for both the climo and the
+    # full-range passes); fall back to the climatology range if not supplied.
+    is_baseline = case_name == self.get_baseline_info("cam_case_name")
+    if is_baseline:
         expname = f'{self.get_baseline_info("cam_case_name")}'
-        start_years = str(self.climo_yrs["syear_baseline"]).zfill(4)
-        end_years   = str(self.climo_yrs["eyear_baseline"]).zfill(4)
-        date_range_string = f"{start_years}01-{end_years}12"
     else:
         expname = f'{self.get_cam_info("cam_case_name")[0]}'
-        date_range_string = date_range_string_case
+
+    if syear is not None and eyear is not None:
+        start_years = str(syear).zfill(4)
+        end_years   = str(eyear).zfill(4)
+    elif is_baseline:
+        start_years = str(self.climo_yrs["syear_baseline"]).zfill(4)
+        end_years   = str(self.climo_yrs["eyear_baseline"]).zfill(4)
+    else:
+        start_years = str(self.climo_yrs["syears"][0]).zfill(4)
+        end_years   = str(self.climo_yrs["eyears"][0]).zfill(4)
+    date_range_string = f"{start_years}01-{end_years}12"
 
     # Grab all required time series files for derived variable (specific match)
     constit_files = []

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -727,10 +727,16 @@ class AdfDiag(AdfWeb):
                 # Finally, run through the derived variables if applicable
                 if constit_dict:
                     for der_var, constit_list in constit_dict.items():
+                        # Pass the actual years of THIS pass (full-range years in
+                        # the full_range pass) so the constituent time series are
+                        # matched in the directory they were just written to. Using
+                        # the climo range here would fail to find the full-range
+                        # constituents, so no derived time series would be produced.
                         derive_variable(self, case_name, der_var,
                                         res=res, ts_dir=ts_dir,
                                         constit_list=constit_list,
-                                        hist_str=hist_str)
+                                        hist_str=hist_str,
+                                        syear=start_year, eyear=end_year)
 
                 # Regrid native spectral-element (ncol) time series to lat/lon,
                 # in parallel, if a SE grid is configured.  This overwrites each


### PR DESCRIPTION
This PR fixes #46 

Some variables aren't in the model output — ADF builds them. PRECT (total precipitation) isn't written by the model. ADF makes it by adding two things that are written: PRECC (convective) + PRECL (large-scale). 

Files are named by their year range. Every time-series file has the years baked into its name:
CASE.h0.PRECL.000101-003012.nc   ← years 1–30

With global_mean_ts_full_range: true, ADF now builds a second set of time series over the whole run, in its own folder:
tseries/s0001-e0030/   ← climatology window (say years 1–30)
tseries/s0001-e0100/   ← full range (years 1–100)  ← the drift plot reads this one

The problem is that derivation step was looking in the wrong place — by year. To build PRECT, ADF first has to find its ingredients, PRECL and PRECC. But the code that searched for them always used the climatology years (1–30), even when it was working in the full-range folder. So in s0001-e0100/ it looked for ...PRECL.000101-003012.nc — a file that only exists over there in s0001-e0030/. It found nothing, gave up, and never built PRECT in the full-range folder.

Result: the drift plot reads the full-range folder, PRECT (and every other derived variable — RESTOM, cloud forcing, the emission/flux ones) simply isn't there, so it's skipped. That's your 63 → 49: the 14 missing are exactly the derived variables.

With this fix the derivation step use the years of the folder it's actually working in instead of hard-coding the climatology years. So in the full-range folder it now searches for ...PRECL.000101-010012.nc, finds the ingredients, and builds PRECT there too.

